### PR TITLE
Added SIMD/threads memory ops to Memory64 proposal

### DIFF
--- a/proposals/memory64/Overview.md
+++ b/proposals/memory64/Overview.md
@@ -141,6 +141,63 @@ have to support 32-bit memory addresses in their ABI.
       ```
   - (and similar for memory instructions from other proposals)
 
+* The [SIMD proposal][simd] extends `t.load memarg` and `t.store memarg`
+  above such that `t` may now also be `v128`, which accesses a 16-byte quantity
+  in memory that is also 16-byte aligned.
+
+  In addition to this, it also has these SIMD specific memory operations (see
+  [SIMD proposal][simd] for full semantics):
+  - `v128.loadN_zero memarg` (where N = 32/64):
+    Load a single 32-bit or 64-bit element into the lowest bits of a `v128`
+    vector, and initialize all other bits of the `v128` vector to zero.
+  - `v128.loadN_splat memarg` (where N = 8/16/32/64):
+    Load a single element and splat to all lanes of a `v128` vector. The natural
+    alignment is the size of the element loaded.
+  - `v128.loadN_lane memarg v128 immlaneidx` (where N = 8/16/32/64):
+    Load a single element from `memarg` into the lane of the `v128` specified in
+    the immediate mode operand `immlaneidx`. The values of all other lanes of
+    the `v128` are bypassed as is.
+  - `v128.storeN_lane memarg v128 immlaneidx` (where N = 8/16/32/64):
+    Store into `memarg` the lane of `v128` specified in the immediate mode
+    operand `immlaneidx`.
+  - `v128.loadL_sx memarg` (where L is `8x8`/`16x4`/`32x2`, and sx is `s`/`u`):
+    Fetch consecutive integers up to 32-bit wide and produce a vector with lanes
+    up to 64 bits. The natural alignment is 8 bytes.
+
+  All these operations now take 64-bit address operands when used with a
+  64-bit memory.
+
+* The [Threads proposal][threads] has `atomic` versions of `t.load`, `t.store`,
+  (and `t.loadN_u` / `t.storeN_u`, no sign-extend) specified above, except with
+  `.` replaced by `.atomic.`, and the guarantee of ordering of accesses being
+  sequentially consistent.
+
+  In addition to this, it has the following memory operations (see
+  [Threads proposal][threads] for full semantics):
+  - `t.atomic.rmwN.op_u memarg` (where t = 32/64, N = 8/16/32 when < t or empty
+    otherwise, op is `add`/`sub`/`and`/`or`/`xor`/`xchg`/`cmpxchg`, and `_u`
+    only present when N is not empty):
+    The first 6 operations atomically read a value from an address, modify the
+    value, and store the resulting value to the same address. They then return
+    the value read from memory before the modify operation was performed.
+    In the case of `cmpxchg`, the operands are an address, an expected value,
+    and a replacement value. If the loaded value is equal to the expected value,
+    the replacement value is stored to the same memory address. If the values
+    are not equal, no value is stored. In either case, the loaded value is
+    returned.
+  - `memory.atomic.waitN` (where N = 32/64):
+    The wait operator take three operands: an address operand, an expected
+    value, and a relative timeout in nanoseconds as an `i64`. The return value
+    is `0`, `1`, or `2`, returned as an `i32`.
+  - `memory.atomic.notify`:
+    The notify operator takes two operands: an address operand and a count as an
+    unsigned `i32`. The operation will notify as many waiters as are waiting on
+    the same effective address, up to the maximum as specified by count. The
+    operator returns the number of waiters that were woken as an unsigned `i32`.
+
+  All these operations now take 64-bit address operands when used with a
+  64-bit memory.
+
 * The [Multi-memory proposal][multi memory] extends each of these instructions
   with one or two memory index immediates. The index type for that memory will
   be used. For example,
@@ -273,3 +330,5 @@ have to support 32-bit memory addresses in their ABI.
 [text memtype]: https://webassembly.github.io/spec/core/text/types.html#text-memtype
 [text memabbrev]: https://webassembly.github.io/spec/core/text/modules.html#text-mem-abbrev
 [multi memory]: https://github.com/webassembly/multi-memory
+[simd]: https://github.com/webassembly/simd
+[threads]: https://github.com/webassembly/threads


### PR DESCRIPTION
Essentially this just allows 64-bit address operands, so kept it to just a minimal description of the instructions affected.