### PR TITLE
WebAssembly.Memory "index: u32/u64" constructor parameter

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -607,10 +607,15 @@ interface Instance {
 <h3 id="memories">Memories</h3>
 
 <pre class="idl">
+enum MemoryIndexType {
+  "u32",
+  "u64",
+};
+
 dictionary MemoryDescriptor {
   required [EnforceRange] unsigned long initial;
   [EnforceRange] unsigned long maximum;
-  boolean memory64;
+  MemoryIndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=(Window,Worker,Worklet)]
@@ -663,8 +668,8 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |initial| be |descriptor|["initial"].
     1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
     1. If |maximum| is not empty and |maximum| &lt; |initial|, throw a {{RangeError}} exception.
-    1. If |descriptior|["memory64"] [=map/exists=], let |memory64| be |descriptor|["memory64"]; otherwise, let |memory64| be false.
-    1. Let |memtype| be { min |initial|, max |maximum|, memory64 |memory64| }.
+    1. If |descriptior|["index"] [=map/exists=], let |index| be |descriptor|["index"]; otherwise, let |index| be "u32".
+    1. Let |memtype| be { min |initial|, max |maximum|, index |index| }.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |memaddr|) be [=mem_alloc=](|store|, |memtype|). If allocation fails, throw a {{RangeError}} exception.
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -610,6 +610,7 @@ interface Instance {
 dictionary MemoryDescriptor {
   required [EnforceRange] unsigned long initial;
   [EnforceRange] unsigned long maximum;
+  boolean memory64;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=(Window,Worker,Worklet)]
@@ -662,7 +663,8 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |initial| be |descriptor|["initial"].
     1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
     1. If |maximum| is not empty and |maximum| &lt; |initial|, throw a {{RangeError}} exception.
-    1. Let |memtype| be { min |initial|, max |maximum| }.
+    1. If |descriptior|["memory64"] [=map/exists=], let |memory64| be |descriptor|["memory64"]; otherwise, let |memory64| be false.
+    1. Let |memtype| be { min |initial|, max |maximum|, memory64 |memory64| }.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |memaddr|) be [=mem_alloc=](|store|, |memtype|). If allocation fails, throw a {{RangeError}} exception.
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.

--- a/test/js-api/memory/assertions.js
+++ b/test/js-api/memory/assertions.js
@@ -27,7 +27,7 @@ function assert_ArrayBuffer(actual, { size=0, shared=false, detached=false }, me
   assert_equals(Object.isExtensible(actual), !shared, "buffer extensibility");
 }
 
-function assert_Memory(memory, { size=0, shared=false }) {
+function assert_Memory(memory, { size=0, shared=false, index="u32" }) {
   assert_equals(Object.getPrototypeOf(memory), WebAssembly.Memory.prototype,
                 "prototype");
   assert_true(Object.isExtensible(memory), "extensible");
@@ -35,4 +35,9 @@ function assert_Memory(memory, { size=0, shared=false }) {
   // https://github.com/WebAssembly/spec/issues/840
   assert_equals(memory.buffer, memory.buffer, "buffer should be idempotent");
   assert_ArrayBuffer(memory.buffer, { size, shared });
+
+  // this depends on js-types proposal implementation
+  if (typeof memory.type == "function") {
+    assert_equals(memory.type().index, index, "memory index");
+  }
 }

--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -135,27 +135,31 @@ test(() => {
 test(() => {
   const argument = { "initial": 1 };
   const memory = new WebAssembly.Memory(argument);
-  assert_equals(memory.type().index, "u32");
-}, "Memory with default constructor");
+  assert_Memory(memory, { "size": 1, "index": "u32" });
+}, "Memory with index parameter omitted");
 
 test(() => {
   const argument = { "initial": 1, "index": "u32" };
   const memory = new WebAssembly.Memory(argument);
-  assert_equals(memory.type().index, "u32");
+  assert_Memory(memory, { "size": 1, "index": "u32" });
 }, "Memory with u32 index constructor");
 
 test(() => {
   const argument = { "initial": 1, "index": "u64" };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1 });
-  assert_equals(memory.type().index, "u64");
+  assert_Memory(memory, { "size": 1, "index": "u64" });
 }, "Memory with u64 index constructor");
 
 test(() => {
-  const argument = { "initial": 1, "index": "u64", shared: true };
+  const argument = { "initial": 1, "maximum": 2, "index": "u32", shared: true };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1 });
-  assert_equals(memory.type().index, "u64");
+  assert_Memory(memory, { "size": 1, "index": "u32", shared: true });
+}, "Shared memory with u32 index constructor");
+
+test(() => {
+  const argument = { "initial": 1, "maximum": 2, "index": "u64", shared: true };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 1, "index": "u64", shared: true });
 }, "Shared memory with u64 index constructor");
 
 test(() => {

--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -72,6 +72,9 @@ test(() => {
       assert_unreached(`Should not call [[HasProperty]] with ${x}`);
     },
     get(o, x) {
+      if (x === "index") {
+        return "u32";
+      }
       return 0;
     },
   });
@@ -128,3 +131,33 @@ test(() => {
   const memory = new WebAssembly.Memory(argument, {});
   assert_Memory(memory, { "size": 0 });
 }, "Stray argument");
+
+test(() => {
+  const argument = { "initial": 1 };
+  const memory = new WebAssembly.Memory(argument);
+  assert_equals(memory.type().index, "u32");
+}, "Memory with default constructor");
+
+test(() => {
+  const argument = { "initial": 1, "index": "u32" };
+  const memory = new WebAssembly.Memory(argument);
+  assert_equals(memory.type().index, "u32");
+}, "Memory with u32 index constructor");
+
+test(() => {
+  const argument = { "initial": 1, "index": "u64" };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 1 });
+  assert_equals(memory.type().index, "u64");
+}, "Memory with u64 index constructor");
+
+test(() => {
+  const argument = { "initial": 1, "index": "u64", shared: true };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 1 });
+  assert_equals(memory.type().index, "u64");
+}, "Shared memory with u64 index constructor");
+
+test(() => {
+  assert_throws_js(TypeError, () => new WebAssembly.Memory({ "initial": 1, "index": "none" }));
+}, "Unknown memory index");

--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -151,17 +151,5 @@ test(() => {
 }, "Memory with u64 index constructor");
 
 test(() => {
-  const argument = { "initial": 1, "maximum": 2, "index": "u32", shared: true };
-  const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "index": "u32", shared: true });
-}, "Shared memory with u32 index constructor");
-
-test(() => {
-  const argument = { "initial": 1, "maximum": 2, "index": "u64", shared: true };
-  const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "index": "u64", shared: true });
-}, "Shared memory with u64 index constructor");
-
-test(() => {
   assert_throws_js(TypeError, () => new WebAssembly.Memory({ "initial": 1, "index": "none" }));
 }, "Unknown memory index");


### PR DESCRIPTION
Currently spec does not allow creating 64 bit memory from JS code, so there is no way to create a shared memory instance with more than 65,536 pages.

I propose to add an optional parameter that would create a 64 bit memory instance without those limits.