### PR TITLE
Changed memory index from u32/u64 to i32/i64

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -608,8 +608,8 @@ interface Instance {
 
 <pre class="idl">
 enum MemoryIndexType {
-  "u32",
-  "u64",
+  "i32",
+  "i64",
 };
 
 dictionary MemoryDescriptor {
@@ -668,7 +668,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |initial| be |descriptor|["initial"].
     1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
     1. If |maximum| is not empty and |maximum| &lt; |initial|, throw a {{RangeError}} exception.
-    1. If |descriptior|["index"] [=map/exists=], let |index| be |descriptor|["index"]; otherwise, let |index| be "u32".
+    1. If |descriptior|["index"] [=map/exists=], let |index| be |descriptor|["index"]; otherwise, let |index| be "i32".
     1. Let |memtype| be { min |initial|, max |maximum|, index |index| }.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |memaddr|) be [=mem_alloc=](|store|, |memtype|). If allocation fails, throw a {{RangeError}} exception.

--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -73,7 +73,7 @@ test(() => {
     },
     get(o, x) {
       if (x === "index") {
-        return "u32";
+        return "i32";
       }
       return 0;
     },
@@ -135,20 +135,20 @@ test(() => {
 test(() => {
   const argument = { "initial": 1 };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "index": "u32" });
+  assert_Memory(memory, { "size": 1, "index": "i32" });
 }, "Memory with index parameter omitted");
 
 test(() => {
-  const argument = { "initial": 1, "index": "u32" };
+  const argument = { "initial": 1, "index": "i32" };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "index": "u32" });
-}, "Memory with u32 index constructor");
+  assert_Memory(memory, { "size": 1, "index": "i32" });
+}, "Memory with i32 index constructor");
 
 test(() => {
-  const argument = { "initial": 1, "index": "u64" };
+  const argument = { "initial": 1, "index": "i64" };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "index": "u64" });
-}, "Memory with u64 index constructor");
+  assert_Memory(memory, { "size": 1, "index": "i64" });
+}, "Memory with i64 index constructor");
 
 test(() => {
   assert_throws_js(TypeError, () => new WebAssembly.Memory({ "initial": 1, "index": "none" }));


### PR DESCRIPTION
Updated to maximize spec compatibility as requested here https://github.com/WebAssembly/memory64/pull/39#issuecomment-1690791616