### PR TITLE
[ci] Add --experimental-wasm-memory64 to node flags

### DIFF
--- a/.github/workflows/ci-interpreter.yml
+++ b/.github/workflows/ci-interpreter.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Build interpreter
         run: cd interpreter && opam exec make
       - name: Run tests
-        run: cd interpreter && opam exec make JS=node ci
+        run: cd interpreter && opam exec make JS="node --experimental-wasm-memory64"  ci


### PR DESCRIPTION
This fixes the current CI failures.