### PR TITLE
Fix error in type of memory.init introduced in #56

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -407,7 +407,7 @@ let rec check_instr (c : context) (e : instr) (s : infer_result_type) : op_type 
   | MemoryInit x ->
     let MemoryType (_, it) = memory c (0l @@ e.at) in
     ignore (data c x);
-    [value_type_of_index_type it; value_type_of_index_type it; value_type_of_index_type it] --> []
+    [value_type_of_index_type it; NumType I32Type; NumType I32Type] --> []
 
   | DataDrop x ->
     ignore (data c x);

--- a/test/core/memory_init.wast
+++ b/test/core/memory_init.wast
@@ -1017,7 +1017,7 @@
   (data (i64.const 12) "\07\05\02\03\06")
   (data "\05\09\02\07\06")
   (func (export "test")
-    (memory.init 1 (i64.const 7) (i64.const 0) (i64.const 4)))
+    (memory.init 1 (i64.const 7) (i32.const 0) (i32.const 4)))
   (func (export "load8_u") (param i64) (result i32)
     (i32.load8_u (local.get 0))))
 
@@ -1061,7 +1061,7 @@
   (data (i64.const 12) "\07\05\02\03\06")
   (data "\05\09\02\07\06")
   (func (export "test")
-    (memory.init 3 (i64.const 15) (i64.const 1) (i64.const 3)))
+    (memory.init 3 (i64.const 15) (i32.const 1) (i32.const 3)))
   (func (export "load8_u") (param i64) (result i32)
     (i32.load8_u (local.get 0))))
 
@@ -1105,9 +1105,9 @@
   (data (i64.const 12) "\07\05\02\03\06")
   (data "\05\09\02\07\06")
   (func (export "test")
-    (memory.init 1 (i64.const 7) (i64.const 0) (i64.const 4))
+    (memory.init 1 (i64.const 7) (i32.const 0) (i32.const 4))
     (data.drop 1)
-    (memory.init 3 (i64.const 15) (i64.const 1) (i64.const 3))
+    (memory.init 3 (i64.const 15) (i32.const 1) (i32.const 3))
     (data.drop 3)
     (memory.copy (i64.const 20) (i64.const 15) (i64.const 5))
     (memory.copy (i64.const 21) (i64.const 29) (i64.const 1))
@@ -1176,20 +1176,20 @@
     (data "\37")
   (func (export "test")
     (data.drop 0)
-    (memory.init 0 (i64.const 1234) (i64.const 1) (i64.const 1))))
+    (memory.init 0 (i64.const 1234) (i32.const 1) (i32.const 1))))
 (assert_trap (invoke "test") "out of bounds memory access")
 
 (module
    (memory i64 1)
    (data (i64.const 0) "\37")
    (func (export "test")
-     (memory.init 0 (i64.const 1234) (i64.const 1) (i64.const 1))))
+     (memory.init 0 (i64.const 1234) (i32.const 1) (i32.const 1))))
 (assert_trap (invoke "test") "out of bounds memory access")
 
 (assert_invalid
   (module
     (func (export "test")
-      (memory.init 1 (i64.const 1234) (i64.const 1) (i64.const 1))))
+      (memory.init 1 (i64.const 1234) (i32.const 1) (i32.const 1))))
   "unknown memory 0")
 
 (assert_invalid
@@ -1197,78 +1197,78 @@
     (memory i64 1)
     (data "\37")
     (func (export "test")
-      (memory.init 1 (i64.const 1234) (i64.const 1) (i64.const 1))))
+      (memory.init 1 (i64.const 1234) (i32.const 1) (i32.const 1))))
   "unknown data segment 1")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 1) (i64.const 0) (i64.const 1))
-    (memory.init 0 (i64.const 1) (i64.const 0) (i64.const 1))))
+    (memory.init 0 (i64.const 1) (i32.const 0) (i32.const 1))
+    (memory.init 0 (i64.const 1) (i32.const 0) (i32.const 1))))
 (invoke "test")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 1234) (i64.const 0) (i64.const 5))))
+    (memory.init 0 (i64.const 1234) (i32.const 0) (i32.const 5))))
 (assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 1234) (i64.const 2) (i64.const 3))))
+    (memory.init 0 (i64.const 1234) (i32.const 2) (i32.const 3))))
 (assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 0xFFFE) (i64.const 1) (i64.const 3))))
+    (memory.init 0 (i64.const 0xFFFE) (i32.const 1) (i32.const 3))))
 (assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 1234) (i64.const 4) (i64.const 0))))
+    (memory.init 0 (i64.const 1234) (i32.const 4) (i32.const 0))))
 (assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 1234) (i64.const 1) (i64.const 0))))
+    (memory.init 0 (i64.const 1234) (i32.const 1) (i32.const 0))))
 (invoke "test")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 0x10001) (i64.const 0) (i64.const 0))))
+    (memory.init 0 (i64.const 0x10001) (i32.const 0) (i32.const 0))))
 (assert_trap (invoke "test") "out of bounds memory access")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 0x10000) (i64.const 0) (i64.const 0))))
+    (memory.init 0 (i64.const 0x10000) (i32.const 0) (i32.const 0))))
 (invoke "test")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 0x10000) (i64.const 1) (i64.const 0))))
+    (memory.init 0 (i64.const 0x10000) (i32.const 1) (i32.const 0))))
 (invoke "test")
 
 (module
   (memory i64 1)
     (data "\37")
   (func (export "test")
-    (memory.init 0 (i64.const 0x10001) (i64.const 4) (i64.const 0))))
+    (memory.init 0 (i64.const 0x10001) (i32.const 4) (i32.const 0))))
 (assert_trap (invoke "test") "out of bounds memory access")
 
 (assert_invalid
@@ -1532,14 +1532,6 @@
     (memory i64 1)
     (data "\37")
     (func (export "test")
-      (memory.init 0 (i64.const 1) (i32.const 1) (i32.const 1))))
-  "type mismatch")
-
-(assert_invalid
-  (module
-    (memory i64 1)
-    (data "\37")
-    (func (export "test")
       (memory.init 0 (i64.const 1) (i32.const 1) (f32.const 1))))
   "type mismatch")
 
@@ -1605,6 +1597,14 @@
     (data "\37")
     (func (export "test")
       (memory.init 0 (i64.const 1) (i64.const 1) (f32.const 1))))
+  "type mismatch")
+
+(assert_invalid
+  (module
+    (memory i64 1)
+    (data "\37")
+    (func (export "test")
+      (memory.init 0 (i64.const 1) (i64.const 1) (i64.const 1))))
   "type mismatch")
 
 (assert_invalid
@@ -1790,10 +1790,10 @@
           (br $cont))))
     (return (local.get $from)))
 
-  (func (export "run") (param $offs i64) (param $len i64)
-    (memory.init 0 (local.get $offs) (i64.const 0) (local.get $len))))
+  (func (export "run") (param $offs i64) (param $len i32)
+    (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
-(assert_trap (invoke "run" (i64.const 65528) (i64.const 16))
+(assert_trap (invoke "run" (i64.const 65528) (i32.const 16))
               "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i64.const 0) (i64.const 1) (i32.const 0))
@@ -1813,10 +1813,10 @@
           (br $cont))))
     (return (local.get $from)))
 
-  (func (export "run") (param $offs i64) (param $len i64)
-    (memory.init 0 (local.get $offs) (i64.const 0) (local.get $len))))
+  (func (export "run") (param $offs i64) (param $len i32)
+    (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
-(assert_trap (invoke "run" (i64.const 65527) (i64.const 16))
+(assert_trap (invoke "run" (i64.const 65527) (i32.const 16))
               "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i64.const 0) (i64.const 1) (i32.const 0))
@@ -1836,10 +1836,10 @@
           (br $cont))))
     (return (local.get $from)))
 
-  (func (export "run") (param $offs i64) (param $len i64)
-    (memory.init 0 (local.get $offs) (i64.const 0) (local.get $len))))
+  (func (export "run") (param $offs i64) (param $len i32)
+    (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
-(assert_trap (invoke "run" (i64.const 65472) (i64.const 30))
+(assert_trap (invoke "run" (i64.const 65472) (i32.const 30))
               "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i64.const 0) (i64.const 1) (i32.const 0))
@@ -1859,10 +1859,10 @@
           (br $cont))))
     (return (local.get $from)))
 
-  (func (export "run") (param $offs i64) (param $len i64)
-    (memory.init 0 (local.get $offs) (i64.const 0) (local.get $len))))
+  (func (export "run") (param $offs i64) (param $len i32)
+    (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
-(assert_trap (invoke "run" (i64.const 65473) (i64.const 31))
+(assert_trap (invoke "run" (i64.const 65473) (i32.const 31))
               "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i64.const 0) (i64.const 1) (i32.const 0))
@@ -1882,10 +1882,10 @@
           (br $cont))))
     (return (local.get $from)))
 
-  (func (export "run") (param $offs i64) (param $len i64)
-    (memory.init 0 (local.get $offs) (i64.const 0) (local.get $len))))
+  (func (export "run") (param $offs i64) (param $len i32)
+    (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
-(assert_trap (invoke "run" (i64.const 65528) (i64.const 4294967040))
+(assert_trap (invoke "run" (i64.const 65528) (i32.const 4294967040))
               "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i64.const 0) (i64.const 1) (i32.const 0))
@@ -1905,10 +1905,10 @@
           (br $cont))))
     (return (local.get $from)))
 
-  (func (export "run") (param $offs i64) (param $len i64)
-    (memory.init 0 (local.get $offs) (i64.const 0) (local.get $len))))
+  (func (export "run") (param $offs i64) (param $len i32)
+    (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 
-(assert_trap (invoke "run" (i64.const 0) (i64.const 4294967292))
+(assert_trap (invoke "run" (i64.const 0) (i32.const 4294967292))
               "out of bounds memory access")
 
 (assert_return (invoke "checkRange" (i64.const 0) (i64.const 1) (i32.const 0))
@@ -1927,4 +1927,4 @@
   (data "") (data "") (data "") (data "") (data "") (data "") (data "") (data "")
   (data "") (data "") (data "") (data "") (data "") (data "") (data "") (data "")
   (data "")
-  (func (memory.init 64 (i64.const 0) (i64.const 0) (i64.const 0))))
+  (func (memory.init 64 (i64.const 0) (i32.const 0) (i32.const 0))))

--- a/test/meta/generate_memory_init.js
+++ b/test/meta/generate_memory_init.js
@@ -37,17 +37,17 @@ for ( const memtype of ['i32', 'i64'] ) {
            [e,e,3,1,4, 1,e,e,e,e, e,e,7,5,2, 3,6,e,e,e, e,e,e,e,e, e,e,e,e,e]);
 
   // Passive init that overwrites all-zero entries
-  mem_test(`(memory.init 1 (${memtype}.const 7) (${memtype}.const 0) (${memtype}.const 4))`,
+  mem_test(`(memory.init 1 (${memtype}.const 7) (i32.const 0) (i32.const 4))`,
            [e,e,3,1,4, 1,e,2,7,1, 8,e,7,5,2, 3,6,e,e,e, e,e,e,e,e, e,e,e,e,e]);
 
   // Passive init that overwrites existing active-init-created entries
-  mem_test(`(memory.init 3 (${memtype}.const 15) (${memtype}.const 1) (${memtype}.const 3))`,
+  mem_test(`(memory.init 3 (${memtype}.const 15) (i32.const 1) (i32.const 3))`,
            [e,e,3,1,4, 1,e,e,e,e, e,e,7,5,2, 9,2,7,e,e, e,e,e,e,e, e,e,e,e,e]);
 
   // Perform active and passive initialisation and then multiple copies
-  mem_test(`(memory.init 1 (${memtype}.const 7) (${memtype}.const 0) (${memtype}.const 4))
+  mem_test(`(memory.init 1 (${memtype}.const 7) (i32.const 0) (i32.const 4))
     (data.drop 1)
-    (memory.init 3 (${memtype}.const 15) (${memtype}.const 1) (${memtype}.const 3))
+    (memory.init 3 (${memtype}.const 15) (i32.const 1) (i32.const 3))
     (data.drop 3)
     (memory.copy (${memtype}.const 20) (${memtype}.const 15) (${memtype}.const 5))
     (memory.copy (${memtype}.const 21) (${memtype}.const 29) (${memtype}.const 1))
@@ -97,7 +97,7 @@ for ( const memtype of ['i32', 'i64'] ) {
   ${PREAMBLE}
   (func (export "test")
     (data.drop 0)
-    (memory.init 0 (${memtype}.const 1234) (${memtype}.const 1) (${memtype}.const 1))))
+    (memory.init 0 (${memtype}.const 1234) (i32.const 1) (i32.const 1))))
 (assert_trap (invoke "test") "out of bounds memory access")
 `);
 
@@ -107,7 +107,7 @@ for ( const memtype of ['i32', 'i64'] ) {
    (memory${decltype} 1)
    (data (${memtype}.const 0) "\\37")
    (func (export "test")
-     (memory.init 0 (${memtype}.const 1234) (${memtype}.const 1) (${memtype}.const 1))))
+     (memory.init 0 (${memtype}.const 1234) (i32.const 1) (i32.const 1))))
 (assert_trap (invoke "test") "out of bounds memory access")
 `);
 
@@ -116,7 +116,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(assert_invalid
   (module
     (func (export "test")
-      (memory.init 1 (${memtype}.const 1234) (${memtype}.const 1) (${memtype}.const 1))))
+      (memory.init 1 (${memtype}.const 1234) (i32.const 1) (i32.const 1))))
   "unknown memory 0")
 `);
 
@@ -126,7 +126,7 @@ for ( const memtype of ['i32', 'i64'] ) {
   (module
     ${PREAMBLE}
     (func (export "test")
-      (memory.init 1 (${memtype}.const 1234) (${memtype}.const 1) (${memtype}.const 1))))
+      (memory.init 1 (${memtype}.const 1234) (i32.const 1) (i32.const 1))))
   "unknown data segment 1")
 `);
 
@@ -135,8 +135,8 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 1) (${memtype}.const 0) (${memtype}.const 1))
-    (memory.init 0 (${memtype}.const 1) (${memtype}.const 0) (${memtype}.const 1))))
+    (memory.init 0 (${memtype}.const 1) (i32.const 0) (i32.const 1))
+    (memory.init 0 (${memtype}.const 1) (i32.const 0) (i32.const 1))))
 (invoke "test")
 `);
 
@@ -145,7 +145,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 1234) (${memtype}.const 0) (${memtype}.const 5))))
+    (memory.init 0 (${memtype}.const 1234) (i32.const 0) (i32.const 5))))
 (assert_trap (invoke "test") "out of bounds memory access")
 `);
 
@@ -154,7 +154,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 1234) (${memtype}.const 2) (${memtype}.const 3))))
+    (memory.init 0 (${memtype}.const 1234) (i32.const 2) (i32.const 3))))
 (assert_trap (invoke "test") "out of bounds memory access")
 `);
 
@@ -163,7 +163,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 0xFFFE) (${memtype}.const 1) (${memtype}.const 3))))
+    (memory.init 0 (${memtype}.const 0xFFFE) (i32.const 1) (i32.const 3))))
 (assert_trap (invoke "test") "out of bounds memory access")
 `);
 
@@ -172,7 +172,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 1234) (${memtype}.const 4) (${memtype}.const 0))))
+    (memory.init 0 (${memtype}.const 1234) (i32.const 4) (i32.const 0))))
 (assert_trap (invoke "test") "out of bounds memory access")
 `);
 
@@ -181,7 +181,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 1234) (${memtype}.const 1) (${memtype}.const 0))))
+    (memory.init 0 (${memtype}.const 1234) (i32.const 1) (i32.const 0))))
 (invoke "test")
 `);
 
@@ -190,7 +190,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 0x10001) (${memtype}.const 0) (${memtype}.const 0))))
+    (memory.init 0 (${memtype}.const 0x10001) (i32.const 0) (i32.const 0))))
 (assert_trap (invoke "test") "out of bounds memory access")
 `);
 
@@ -199,7 +199,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 0x10000) (${memtype}.const 0) (${memtype}.const 0))))
+    (memory.init 0 (${memtype}.const 0x10000) (i32.const 0) (i32.const 0))))
 (invoke "test")
 `);
 
@@ -208,7 +208,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 0x10000) (${memtype}.const 1) (${memtype}.const 0))))
+    (memory.init 0 (${memtype}.const 0x10000) (i32.const 1) (i32.const 0))))
 (invoke "test")
 `);
 
@@ -218,7 +218,7 @@ for ( const memtype of ['i32', 'i64'] ) {
 `(module
   ${PREAMBLE}
   (func (export "test")
-    (memory.init 0 (${memtype}.const 0x10001) (${memtype}.const 4) (${memtype}.const 0))))
+    (memory.init 0 (${memtype}.const 0x10001) (i32.const 4) (i32.const 0))))
 (assert_trap (invoke "test") "out of bounds memory access")
 `);
 
@@ -229,7 +229,7 @@ for ( const memtype of ['i32', 'i64'] ) {
       for (let ty1 of tys) {
       for (let ty2 of tys) {
       for (let ty3 of tys) {
-          if (ty1 == memtype && ty2 == memtype && ty3 == memtype)
+          if (ty1 == memtype && ty2 == 'i32' && ty3 == 'i32')
               continue;  // this is the only valid case
           print(
 `(assert_invalid
@@ -257,8 +257,8 @@ for ( const memtype of ['i32', 'i64'] ) {
   (memory${decltype} ${min} ${max} ${shared})
   (data "\\42\\42\\42\\42\\42\\42\\42\\42\\42\\42\\42\\42\\42\\42\\42\\42")
    ${checkRangeCode(memtype)}
-  (func (export "run") (param $offs ${memtype}) (param $len ${memtype})
-    (memory.init 0 (local.get $offs) (${memtype}.const 0) (local.get $len))))
+  (func (export "run") (param $offs ${memtype}) (param $len i32)
+    (memory.init 0 (local.get $offs) (i32.const 0) (local.get $len))))
 `);
       // A fill writing past the end of the memory should throw *and* have filled
       // all the way up to the end.
@@ -267,7 +267,7 @@ for ( const memtype of ['i32', 'i64'] ) {
       // memory with as much data as was available.
       let offs = min*PAGESIZE - backup;
       print(
-`(assert_trap (invoke "run" (${memtype}.const ${offs}) (${memtype}.const ${write}))
+`(assert_trap (invoke "run" (${memtype}.const ${offs}) (i32.const ${write}))
               "out of bounds memory access")
 `);
       checkRange(memtype, 0, min, 0);
@@ -312,5 +312,5 @@ for ( const memtype of ['i32', 'i64'] ) {
   (data "") (data "") (data "") (data "") (data "") (data "") (data "") (data "")
   (data "") (data "") (data "") (data "") (data "") (data "") (data "") (data "")
   (data "")
-  (func (memory.init 64 (${memtype}.const 0) (${memtype}.const 0) (${memtype}.const 0))))`)
+  (func (memory.init 64 (${memtype}.const 0) (i32.const 0) (i32.const 0))))`)
 }


### PR DESCRIPTION
Sorry for the churn.  This time I'll double check the test in wabt before updating the testsuite repo.