### PR TITLE
Add index constructor argument for WebAssembly.Table

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -482,6 +482,11 @@ enum ImportExportKind {
   "global"
 };
 
+enum IndexType {
+  "i32",
+  "i64",
+};
+
 dictionary ModuleExportDescriptor {
   required USVString name;
   required ImportExportKind kind;
@@ -584,15 +589,10 @@ Note: The use of this synchronous API is discouraged, as some implementations so
 <h3 id="memories">Memories</h3>
 
 <pre class="idl">
-enum MemoryIndexType {
-  "i32",
-  "i64",
-};
-
 dictionary MemoryDescriptor {
   required [EnforceRange] unsigned long initial;
   [EnforceRange] unsigned long maximum;
-  MemoryIndexType index;
+  IndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]
@@ -779,16 +779,11 @@ enum TableKind {
   // e.g., typed function references, typed GC references
 };
 
-enum TableIndexType {
-  "i32",
-  "i64",
-};
-
 dictionary TableDescriptor {
   required TableKind element;
   required [EnforceRange] unsigned long initial;
   [EnforceRange] unsigned long maximum;
-  TableIndexType index;
+  IndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -779,10 +779,16 @@ enum TableKind {
   // e.g., typed function references, typed GC references
 };
 
+enum TableIndexType {
+  "i32",
+  "i64",
+};
+
 dictionary TableDescriptor {
   required TableKind element;
   required [EnforceRange] unsigned long initial;
   [EnforceRange] unsigned long maximum;
+  TableIndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]
@@ -829,7 +835,8 @@ Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address
         1. Let |ref| be [=DefaultValue=](|elementType|).
     1. Otherwise,
         1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementType|).
-    1. Let |type| be the [=table type=] {[=table type|min=] |initial|, [=table type|max=] |maximum|} |elementType|.
+    1. If |descriptior|["index"] [=map/exists=], let |index| be |descriptor|["index"]; otherwise, let |index| be "i32".
+    1. Let |type| be the [=table type=] [=table type|index=] |index| {[=table type|min=] |initial|, [=table type|max=] |maximum|} [=table type|refType=] |elementType|.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |tableaddr|) be [=table_alloc=](|store|, |type|, |ref|). <!-- TODO(littledan): Report allocation failure https://github.com/WebAssembly/spec/issues/584 -->
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.

--- a/test/js-api/table/constructor.any.js
+++ b/test/js-api/table/constructor.any.js
@@ -157,6 +157,16 @@ test(() => {
         },
       };
     },
+
+    get index() {
+      order.push("index");
+      return {
+        valueOf() {
+          order.push("index valueOf");
+          return "i32";
+        },
+      };
+    },
   });
 
   assert_array_equals(order, [
@@ -166,6 +176,8 @@ test(() => {
     "initial valueOf",
     "maximum",
     "maximum valueOf",
+    "index",
+    "index valueOf",
   ]);
 }, "Order of evaluation for descriptor");
 
@@ -206,3 +218,24 @@ test(() => {
   assert_throws_js(TypeError, () => new WebAssembly.Table(argument, "cannot be used as a wasm function"));
   assert_throws_js(TypeError, () => new WebAssembly.Table(argument, 37));
 }, "initialize anyfunc table with a bad default value");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3, "index": "i32" };
+  const table = new WebAssembly.Table(argument);
+  // Once this is merged with the type reflection proposal we should check the
+  // index type of `table`.
+  assert_equals(table.length, 3);
+}, "Table with i32 index constructor");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3, "index": "i64" };
+  const table = new WebAssembly.Table(argument);
+  // Once this is merged with the type reflection proposal we should check the
+  // index type of `table`.
+  assert_equals(table.length, 3);
+}, "Table with i64 index constructor");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3, "index": "unknown" };
+  assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
+}, "Unknown table index");


### PR DESCRIPTION
Similar to WebAssembly.Memory (#39), the WebAssembly.Table constructor also needs an `index` argument.

This fixes #63.