### PR TITLE
Overview.md - fix Table64 status links

### DIFF
--- a/proposals/memory64/Overview.md
+++ b/proposals/memory64/Overview.md
@@ -23,8 +23,8 @@ made during phase 3 of the proposal and we refer to this addition as "table64".
 ### Implementation Status (table64)
 
 - spec interpreter: [Done](https://github.com/WebAssembly/table64/53)
-- v8/chrome: [WIP](https://g-issues.chromium.org/issues/338024338)
-- Firefox: [WIP](https://g-issues.chromium.org/issues/338024338)
+- v8/chrome: [WIP](https://issues.chromium.org/issues/338024338)
+- Firefox: [WIP](https://bugzilla.mozilla.org/show_bug.cgi?id=1893643)
 - Safari: -
 - wabt: Done
 - binaryen: Done


### PR DESCRIPTION
Fix URLs for Table64 status. Chromium one was a Google internal link, Firefox one was a typo pointing at the same Chromium one.

I submitted this in #60 and it said it was merged, but it somehow never made it into the commit history! Trying again.