### PR TITLE
Update execution, embedding, and JS API specs for Memory64

### DIFF
--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -383,7 +383,7 @@ Tables
 
 .. _embed-table-read:
 
-:math:`\F{table\_read}(\store, \tableaddr, i:\u32) : \reff ~|~ \error`
+:math:`\F{table\_read}(\store, \tableaddr, i:\u64) : \reff ~|~ \error`
 ......................................................................
 
 1. Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
@@ -401,7 +401,7 @@ Tables
 
 .. _embed-table-write:
 
-:math:`\F{table\_write}(\store, \tableaddr, i:\u32, \reff) : \store ~|~ \error`
+:math:`\F{table\_write}(\store, \tableaddr, i:\u64, \reff) : \store ~|~ \error`
 ...............................................................................
 
 1. Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
@@ -421,7 +421,7 @@ Tables
 
 .. _embed-table-size:
 
-:math:`\F{table\_size}(\store, \tableaddr) : \u32`
+:math:`\F{table\_size}(\store, \tableaddr) : \u64`
 ..................................................
 
 1. Return the length of :math:`\store.\STABLES[\tableaddr].\TIELEM`.
@@ -437,7 +437,7 @@ Tables
 
 .. _embed-table-grow:
 
-:math:`\F{table\_grow}(\store, \tableaddr, n:\u32, \reff) : \store ~|~ \error`
+:math:`\F{table\_grow}(\store, \tableaddr, n:\u64, \reff) : \store ~|~ \error`
 ..............................................................................
 
 1. Try :ref:`growing <grow-table>` the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]` by :math:`n` elements with initialization value :math:`\reff`:
@@ -495,7 +495,7 @@ Memories
 
 .. _embed-mem-read:
 
-:math:`\F{mem\_read}(\store, \memaddr, i:\u32) : \byte ~|~ \error`
+:math:`\F{mem\_read}(\store, \memaddr, i:\u64) : \byte ~|~ \error`
 ..................................................................
 
 1. Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
@@ -513,12 +513,12 @@ Memories
 
 .. _embed-mem-write:
 
-:math:`\F{mem\_write}(\store, \memaddr, i:\u32, \byte) : \store ~|~ \error`
+:math:`\F{mem\_write}(\store, \memaddr, i:\u64, \byte) : \store ~|~ \error`
 ...........................................................................
 
 1. Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
 
-2. If :math:`\u32` is larger than or equal to the length of :math:`\X{mi}.\MIDATA`, then return :math:`\ERROR`.
+2. If :math:`i` is larger than or equal to the length of :math:`\X{mi}.\MIDATA`, then return :math:`\ERROR`.
 
 3. Replace :math:`\X{mi}.\MIDATA[i]` with :math:`\byte`.
 
@@ -533,7 +533,7 @@ Memories
 
 .. _embed-mem-size:
 
-:math:`\F{mem\_size}(\store, \memaddr) : \u32`
+:math:`\F{mem\_size}(\store, \memaddr) : \u64`
 ..............................................
 
 1. Return the length of :math:`\store.\SMEMS[\memaddr].\MIDATA` divided by the :ref:`page size <page-size>`.
@@ -549,7 +549,7 @@ Memories
 
 .. _embed-mem-grow:
 
-:math:`\F{mem\_grow}(\store, \memaddr, n:\u32) : \store ~|~ \error`
+:math:`\F{mem\_grow}(\store, \memaddr, n:\u64) : \store ~|~ \error`
 ...................................................................
 
 1. Try :ref:`growing <grow-mem>` the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]` by :math:`n` :ref:`pages <page-size>`:

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -94,11 +94,11 @@ are *allocated* in a :ref:`store <syntax-store>` :math:`S`, as defined by the fo
 
 1. Let :math:`\tabletype` be the :ref:`table type <syntax-tabletype>` of the table to allocate and :math:`\reff` the initialization value.
 
-2. Let :math:`(\{\LMIN~n, \LMAX~m^?\}~\reftype)` be the structure of :ref:`table type <syntax-tabletype>` :math:`\tabletype`.
+2. Let :math:`(\idxtype~\{\LMIN~n, \LMAX~m^?\}~\reftype)` be the structure of :ref:`table type <syntax-tabletype>` :math:`\tabletype`.
 
 3. Let :math:`a` be the first free :ref:`table address <syntax-tableaddr>` in :math:`S`.
 
-4. Let :math:`\tableinst` be the :ref:`table instance <syntax-tableinst>` :math:`\{ \TITYPE~\tabletype', \TIELEM~\reff^n \}` with :math:`n` elements set to :math:`\reff`.
+4. Let :math:`\tableinst` be the :ref:`table instance <syntax-tableinst>` :math:`\{ \TITYPE~\tabletype, \TIELEM~\reff^n \}` with :math:`n` elements set to :math:`\reff`.
 
 5. Append :math:`\tableinst` to the |STABLES| of :math:`S`.
 
@@ -108,7 +108,7 @@ are *allocated* in a :ref:`store <syntax-store>` :math:`S`, as defined by the fo
    \begin{array}{rlll}
    \alloctable(S, \tabletype, \reff) &=& S', \tableaddr \\[1ex]
    \mbox{where:} \hfill \\
-   \tabletype &=& \{\LMIN~n, \LMAX~m^?\}~\reftype \\
+   \tabletype &=& \idxtype~\{\LMIN~n, \LMAX~m^?\}~\reftype \\
    \tableaddr &=& |S.\STABLES| \\
    \tableinst &=& \{ \TITYPE~\tabletype, \TIELEM~\reff^n \} \\
    S' &=& S \compose \{\STABLES~\tableinst\} \\
@@ -123,7 +123,7 @@ are *allocated* in a :ref:`store <syntax-store>` :math:`S`, as defined by the fo
 
 1. Let :math:`\memtype` be the :ref:`memory type <syntax-memtype>` of the memory to allocate.
 
-2. Let :math:`\{\LMIN~n, \LMAX~m^?\}` be the structure of :ref:`memory type <syntax-memtype>` :math:`\memtype`.
+2. Let :math:`(\idxtype~\{\LMIN~n, \LMAX~m^?\})` be the structure of :ref:`memory type <syntax-memtype>` :math:`\memtype`.
 
 3. Let :math:`a` be the first free :ref:`memory address <syntax-memaddr>` in :math:`S`.
 
@@ -137,7 +137,7 @@ are *allocated* in a :ref:`store <syntax-store>` :math:`S`, as defined by the fo
    \begin{array}{rlll}
    \allocmem(S, \memtype) &=& S', \memaddr \\[1ex]
    \mbox{where:} \hfill \\
-   \memtype &=& \{\LMIN~n, \LMAX~m^?\} \\
+   \memtype &=& \idxtype~\{\LMIN~n, \LMAX~m^?\} \\
    \memaddr &=& |S.\SMEMS| \\
    \meminst &=& \{ \MITYPE~\memtype, \MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}} \} \\
    S' &=& S \compose \{\SMEMS~\meminst\} \\
@@ -284,9 +284,9 @@ Growing :ref:`tables <syntax-tableinst>`
 
 2. Let :math:`\X{len}` be :math:`n` added to the length of :math:`\tableinst.\TIELEM`.
 
-3. If :math:`\X{len}` is larger than or equal to :math:`2^{32}`, then fail.
+3. If :math:`\X{len}` is larger than or equal to :math:`2^{64}`, then fail.
 
-4. Let :math:`\limits~t` be the structure of :ref:`table type <syntax-tabletype>` :math:`\tableinst.\TITYPE`.
+4. Let :math:`(\idxtype~\limits~\reftype)` be the structure of :ref:`table type <syntax-tabletype>` :math:`\tableinst.\TITYPE`.
 
 5. Let :math:`\limits'` be :math:`\limits` with :math:`\LMIN` updated to :math:`\X{len}`.
 
@@ -294,16 +294,16 @@ Growing :ref:`tables <syntax-tableinst>`
 
 7. Append :math:`\reff^n` to :math:`\tableinst.\TIELEM`.
 
-8. Set :math:`\tableinst.\TITYPE` to the :ref:`table type <syntax-tabletype>` :math:`\limits'~t`.
+8. Set :math:`\tableinst.\TITYPE` to the :ref:`table type <syntax-tabletype>` :math:`(\idxtype~\limits'~\reftype)`.
 
 .. math::
    \begin{array}{rllll}
-   \growtable(\tableinst, n, \reff) &=& \tableinst \with \TITYPE = \limits'~t \with \TIELEM = \tableinst.\TIELEM~\reff^n \\
+   \growtable(\tableinst, n, \reff) &=& \tableinst \with \TITYPE = \idxtype~\limits'~\reftype \with \TIELEM = \tableinst.\TIELEM~\reff^n \\
      && (
        \begin{array}[t]{@{}r@{~}l@{}}
        \iff & \X{len} = n + |\tableinst.\TIELEM| \\
-       \wedge & \X{len} < 2^{32} \\
-       \wedge & \limits~t = \tableinst.\TITYPE \\
+       \wedge & \X{len} < 2^{64} \\
+       \wedge & \idxtype~\limits~\reftype = \tableinst.\TITYPE \\
        \wedge & \limits' = \limits \with \LMIN = \X{len} \\
        \wedge & \vdashlimits \limits' \ok) \\
        \end{array} \\
@@ -322,9 +322,9 @@ Growing :ref:`memories <syntax-meminst>`
 
 3. Let :math:`\X{len}` be :math:`n` added to the length of :math:`\meminst.\MIDATA` divided by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`.
 
-4. If :math:`\X{len}` is larger than :math:`2^{16}`, then fail.
+4. If :math:`\X{len}` is larger than :math:`2^{48}`, then fail.
 
-5. Let :math:`\limits` be the structure of :ref:`memory type <syntax-memtype>` :math:`\meminst.\MITYPE`.
+5. Let :math:`(\idxtype~\limits)` be the structure of :ref:`memory type <syntax-memtype>` :math:`\meminst.\MITYPE`.
 
 6. Let :math:`\limits'` be :math:`\limits` with :math:`\LMIN` updated to :math:`\X{len}`.
 
@@ -332,16 +332,16 @@ Growing :ref:`memories <syntax-meminst>`
 
 8. Append :math:`n` times :math:`64\,\F{Ki}` :ref:`bytes <syntax-byte>` with value :math:`\hex{00}` to :math:`\meminst.\MIDATA`.
 
-9. Set :math:`\meminst.\MITYPE` to the :ref:`memory type <syntax-memtype>` :math:`\limits'`.
+9. Set :math:`\meminst.\MITYPE` to the :ref:`memory type <syntax-memtype>` :math:`(\idxtype~\limits')`.
 
 .. math::
    \begin{array}{rllll}
-   \growmem(\meminst, n) &=& \meminst \with \MITYPE = \limits' \with \MIDATA = \meminst.\MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}} \\
+   \growmem(\meminst, n) &=& \meminst \with \MITYPE = \idxtype~\limits' \with \MIDATA = \meminst.\MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}} \\
      && (
        \begin{array}[t]{@{}r@{~}l@{}}
        \iff & \X{len} = n + |\meminst.\MIDATA| / 64\,\F{Ki} \\
-       \wedge & \X{len} \leq 2^{16} \\
-       \wedge & \limits = \meminst.\MITYPE \\
+       \wedge & \X{len} \leq 2^{48} \\
+       \wedge & \idxtype~\limits = \meminst.\MITYPE \\
        \wedge & \limits' = \limits \with \LMIN = \X{len} \\
        \wedge & \vdashlimits \limits' \ok) \\
        \end{array} \\

--- a/document/core/syntax/conventions.rst
+++ b/document/core/syntax/conventions.rst
@@ -123,11 +123,9 @@ Vectors
 
 *Vectors* are bounded sequences of the form :math:`A^n` (or :math:`A^\ast`),
 where the :math:`A` can either be values or complex constructions.
-A vector can have at most :math:`2^{32}-1` elements.
 
 .. math::
    \begin{array}{lllll}
    \production{vector} & \vec(A) &::=&
-     A^n
-     & (\iff n < 2^{32})\\
+     A^n\\
    \end{array}

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -47,6 +47,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: SetFunctionLength; url: sec-setfunctionlength
         text: the Number value; url: sec-ecmascript-language-types-number-type
         text: is a Number; url: sec-ecmascript-language-types-number-type
+        text: is a BigInt; url: sec-ecmascript-language-types-bigint-type
         text: NumberToRawBytes; url: sec-numbertorawbytes
         text: Built-in Function Objects; url: sec-built-in-function-objects
         text: NativeError Object Structure; url: sec-nativeerror-object-structure
@@ -61,6 +62,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: NativeError Object Structure; url: sec-nativeerror-object-structure
         text: 𝔽; url: #𝔽
         text: ℤ; url: #ℤ
+        text: mathematical value; url: #mathematical-value
         text: SameValue; url: sec-samevalue
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
@@ -121,6 +123,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     text: match_valtype; url: appendix/embedding.html#embed-match-valtype
     text: error; url: appendix/embedding.html#embed-error
     text: store; url: exec/runtime.html#syntax-store
+    text: index type; url: syntax/types.html#syntax-idxtype
     text: table type; url: syntax/types.html#syntax-tabletype
     text: table address; url: exec/runtime.html#syntax-tableaddr
     text: function address; url: exec/runtime.html#syntax-funcaddr
@@ -139,6 +142,9 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     text: exn_alloc; url: appendix/embedding.html#embed-exn-alloc
     text: exn_tag; url: appendix/embedding.html#embed-exn-tag
     text: exn_read; url: appendix/embedding.html#embed-exn-read
+    url: syntax/values.html#syntax-int
+        text: u32
+        text: u64
     url: syntax/types.html#syntax-numtype
         text: i32
         text: i64
@@ -200,6 +206,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
 urlPrefix: https://heycam.github.io/webidl/; spec: WebIDL
     type: dfn
         text: create a namespace object; url: create-a-namespace-object
+        text: [EnforceRange]; url: #EnforceRange
 urlPrefix: https://webassembly.github.io/js-types/js-api/; spec: WebAssembly JS API (JS Type Reflection)
     type: abstract-op; text: FromValueType; url: abstract-opdef-fromvaluetype
 urlPrefix: https://tc39.es/proposal-resizablearraybuffer/; spec: ResizableArrayBuffer proposal
@@ -561,6 +568,8 @@ enum IndexType {
   "i64",
 };
 
+typedef ([EnforceRange] unsigned long long or bigint) IndexValue;
+
 dictionary ModuleExportDescriptor {
   required USVString name;
   required ImportExportKind kind;
@@ -665,15 +674,15 @@ Note: The use of this synchronous API is discouraged, as some implementations so
 
 <pre class="idl">
 dictionary MemoryDescriptor {
-  required [EnforceRange] unsigned long long initial;
-  [EnforceRange] unsigned long long maximum;
+  required IndexValue initial;
+  IndexValue maximum;
   IndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]
 interface Memory {
   constructor(MemoryDescriptor descriptor);
-  unsigned long grow([EnforceRange] unsigned long long delta);
+  unsigned long grow(IndexValue delta);
   ArrayBuffer toFixedLengthBuffer();
   ArrayBuffer toResizableBuffer();
   readonly attribute ArrayBuffer buffer;
@@ -736,11 +745,11 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
 
 <div algorithm>
     The <dfn constructor for="Memory">Memory(|descriptor|)</dfn> constructor, when invoked, performs the following steps:
-    1. Let |initial| be |descriptor|["initial"].
-    1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
+    1. If |descriptor|["index"] [=map/exists=], let |indextype| be |descriptor|["index"]; otherwise, let |indextype| be "i32".
+    1. Let |initial| be [=?=] [=IndexValueToU64=](|descriptor|["initial"], |indextype|).
+    1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be [=?=] [=IndexValueToU64=](|descriptor|["maximum"], |indextype|); otherwise, let |maximum| be empty.
     1. If |maximum| is not empty and |maximum| &lt; |initial|, throw a {{RangeError}} exception.
-    1. If |descriptior|["index"] [=map/exists=], let |index| be |descriptor|["index"]; otherwise, let |index| be "i32".
-    1. Let |memtype| be { min |initial|, max |maximum|, index |index| }.
+    1. Let |memtype| be (|indextype|, { **min** |initial|, **max** |maximum| }).
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |memaddr|) be [=mem_alloc=](|store|, |memtype|). If allocation fails, throw a {{RangeError}} exception.
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
@@ -779,7 +788,10 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
 <div algorithm=dom-Memory-grow>
     The <dfn method for="Memory">grow(|delta|)</dfn> method, when invoked, performs the following steps:
     1. Let |memaddr| be **this**.\[[Memory]].
-    1. Return the result of [=grow the memory buffer|growing the memory buffer=] associated with |memaddr| by |delta|.
+    1. Let |store| be the [=surrounding agent=]'s [=associated store=].
+    1. Let |indextype| be the [=index type=] in [=mem_type=](|store|, |memaddr|).
+    1. Let |delta64| be [=?=] [=IndexValueToU64=](|delta|, |indextype|).
+    1. Return the result of [=grow the memory buffer|growing the memory buffer=] associated with |memaddr| by |delta64|.
 </div>
 
 Immediately after a WebAssembly [=memory.grow=] instruction executes, perform the following steps:
@@ -857,18 +869,18 @@ enum TableKind {
 
 dictionary TableDescriptor {
   required TableKind element;
-  required [EnforceRange] unsigned long long initial;
-  [EnforceRange] unsigned long long maximum;
+  required IndexValue initial;
+  IndexValue maximum;
   IndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]
 interface Table {
   constructor(TableDescriptor descriptor, optional any value);
-  unsigned long long grow([EnforceRange] unsigned long long delta, optional any value);
-  any get([EnforceRange] unsigned long long index);
-  undefined set([EnforceRange] unsigned long long index, optional any value);
-  readonly attribute unsigned long length;
+  IndexValue grow(IndexValue delta, optional any value);
+  any get(IndexValue index);
+  undefined set(IndexValue index, optional any value);
+  readonly attribute IndexValue length;
 };
 </pre>
 
@@ -896,19 +908,19 @@ Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address
 
 <div algorithm>
     The <dfn constructor for="Table">Table(|descriptor|, |value|)</dfn> constructor, when invoked, performs the following steps:
-    1. Let |elementType| be [=ToValueType=](|descriptor|["element"]).
-    1. If |elementType| is not a [=reftype=],
-        1. Throw a {{TypeError}} exception.
-    1. Let |initial| be |descriptor|["initial"].
-    1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
+    1. Let |elementtype| be [=ToValueType=](|descriptor|["element"]).
+    1. If |elementtype| is not a [=reftype=],
+        1. [=Throw=] a {{TypeError}} exception.
+    1. If |descriptor|["index"] [=map/exists=], let |indextype| be |descriptor|["index"]; otherwise, let |indextype| be "i32".
+    1. Let |initial| be [=?=] [=IndexValueToU64=](|descriptor|["initial"], |indextype|).
+    1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be [=?=] [=IndexValueToU64=](|descriptor|["maximum"], |indextype|); otherwise, let |maximum| be empty.
     1. If |maximum| is not empty and |maximum| &lt; |initial|, throw a {{RangeError}} exception.
     1. If |value| is missing,
-        1. Let |ref| be [=DefaultValue=](|elementType|).
+        1. Let |ref| be [=DefaultValue=](|elementtype|).
         1. Assert: |ref| is not [=error=].
     1. Otherwise,
-        1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementType|).
-    1. If |descriptior|["index"] [=map/exists=], let |index| be |descriptor|["index"]; otherwise, let |index| be "i32".
-    1. Let |type| be the [=table type=] [=table type|index=] |index| {[=table type|min=] |initial|, [=table type|max=] |maximum|} [=table type|refType=] |elementType|.
+        1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementtype|).
+    1. Let |type| be the [=table type=] (|indextype|, { **min** |initial|, **max** |maximum| }, |elementtype|).
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |tableaddr|) be [=table_alloc=](|store|, |type|, |ref|). <!-- TODO(littledan): Report allocation failure https://github.com/WebAssembly/spec/issues/584 -->
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
@@ -920,13 +932,14 @@ Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address
     1. Let |tableaddr| be **this**.\[[Table]].
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let |initialSize| be [=table_size=](|store|, |tableaddr|).
-    1. Let (<var ignore>limits</var>, |elementType|) be [=table_type=](|tableaddr|).
+    1. Let (|indextype|, <var ignore>limits</var>, |elementtype|) be [=table_type=](|store|, |tableaddr|).
+    1. Let |delta64| be [=?=] [=IndexValueToU64=](|delta|, |indextype|).
     1. If |value| is missing,
-        1. Let |ref| be [=DefaultValue=](|elementType|).
+        1. Let |ref| be [=DefaultValue=](|elementtype|).
         1. If |ref| is [=error=], throw a {{TypeError}} exception.
     1. Otherwise,
-        1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementType|).
-    1. Let |result| be [=table_grow=](|store|, |tableaddr|, |delta|, |ref|).
+        1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementtype|).
+    1. Let |result| be [=table_grow=](|store|, |tableaddr|, |delta64|, |ref|).
     1. If |result| is [=error=], throw a {{RangeError}} exception.
 
         Note: The above exception can happen due to either insufficient memory or an invalid size parameter.
@@ -939,17 +952,20 @@ Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address
     The getter of the <dfn attribute for="Table">length</dfn> attribute of {{Table}}, when invoked, performs the following steps:
     1. Let |tableaddr| be **this**.\[[Table]].
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
-    1. Return [=table_size=](|store|, |tableaddr|).
+    1. Let |indextype| be the [=index type=] in [=table_type=](|store|, |tableaddr|).
+    1. Let |length64| be [=table_size=](|store|, |tableaddr|).
+    1. Return [=U64ToIndexValue=](|length64|, |indextype|).
 </div>
 
 <div algorithm>
     The <dfn method for="Table">get(|index|)</dfn> method, when invoked, performs the following steps:
     1. Let |tableaddr| be **this**.\[[Table]].
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
-    1. Let (<var ignore>limits</var>, |elementType|) be [=table_type=](|store|, |tableaddr|).
-    1. If |elementType| is [=exnref=],
+    1. Let (|indextype|, <var ignore>limits</var>, |elementtype|) be [=table_type=](|store|, |tableaddr|).
+    1. If |elementtype| is [=exnref=],
         1. Throw a {{TypeError}} exception.
-    1. Let |result| be [=table_read=](|store|, |tableaddr|, |index|).
+    1. Let |index64| be [=?=] [=IndexValueToU64=](|index|, |indextype|).
+    1. Let |result| be [=table_read=](|store|, |tableaddr|, |index64|).
     1. If |result| is [=error=], throw a {{RangeError}} exception.
     1. Return [=ToJSValue=](|result|).
 </div>
@@ -958,16 +974,16 @@ Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address
     The <dfn method for="Table">set(|index|, |value|)</dfn> method, when invoked, performs the following steps:
     1. Let |tableaddr| be **this**.\[[Table]].
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
-    1. Let (<var ignore>limits</var>, |elementType|) be [=table_type=](|store|, |tableaddr|).
-    1. If |elementType| is [=exnref=],
+    1. Let (|indextype|, <var ignore>limits</var>, |elementtype|) be [=table_type=](|store|, |tableaddr|).
+    1. If |elementtype| is [=exnref=],
         1. Throw a {{TypeError}} exception.
+    1. Let |index64| be [=?=] [=IndexValueToU64=](|index|, |indextype|).
     1. If |value| is missing,
-        1. Let |ref| be [=DefaultValue=](|elementType|).
+        1. Let |ref| be [=DefaultValue=](|elementtype|).
         1. If |ref| is [=error=], throw a {{TypeError}} exception.
     1. Otherwise,
-        1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementType|).
-    1. Let |store| be the [=surrounding agent=]'s [=associated store=].
-    1. Let |store| be [=table_write=](|store|, |tableaddr|, |index|, |ref|).
+        1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementtype|).
+    1. Let |store| be [=table_write=](|store|, |tableaddr|, |index64|, |ref|).
     1. If |store| is [=error=], throw a {{RangeError}} exception.
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
 </div>
@@ -1236,18 +1252,18 @@ The algorithm <dfn>ToJSValue</dfn>(|w|) coerces a [=WebAssembly value=] to a Jav
 1. Assert: |w| is not of the form [=ref.exn=] <var ignore>exnaddr</var>.
 1. If |w| is of the form [=i64.const=] |u64|,
     1. Let |i64| be [=signed_64=](|u64|).
-    1. Return [=ℤ=](|i64| interpreted as a mathematical value).
-1. If |w| is of the form [=i32.const=] |i32|,
-    1. Let |i32| be [=signed_32=](|i32|).
-    2. Return [=𝔽=](|i32| interpreted as a mathematical value).
+    1. Return [=ℤ=](|i64| interpreted as a [=mathematical value=]).
+1. If |w| is of the form [=i32.const=] |u32|,
+    1. Let |i32| be [=signed_32=](|u32|).
+    2. Return [=𝔽=](|i32| interpreted as a [=mathematical value=]).
 1. If |w| is of the form [=f32.const=] |f32|,
     1. If |f32| is [=+∞=] or [=−∞=], return **+∞**<sub>𝔽</sub> or **-∞**<sub>𝔽</sub>, respectively.
     1. If |f32| is [=nan=], return **NaN**.
-    1. Return [=𝔽=](|f32| interpreted as a mathematical value).
+    1. Return [=𝔽=](|f32| interpreted as a [=mathematical value=]).
 1. If |w| is of the form [=f64.const=] |f64|,
     1. If |f64| is [=+∞=] or [=−∞=], return **+∞**<sub>𝔽</sub> or **-∞**<sub>𝔽</sub>, respectively.
     1. If |f64| is [=nan=], return **NaN**.
-    1. Return [=𝔽=](|f64| interpreted as a mathematical value).
+    1. Return [=𝔽=](|f64| interpreted as a [=mathematical value=]).
 1. If |w| is of the form [=ref.null=] <var ignore>t</var>, return null.
 1. If |w| is of the form [=ref.i31=] |u31|,
     1. Let |i31| be [=signed_31=](|u31|).
@@ -1288,7 +1304,7 @@ The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript va
 1. If |type| is [=f32=],
     1. Let |number| be [=?=] [$ToNumber$](|v|).
     1. If |number| is **NaN**,
-        1. Let |n| be an implementation-defined integer such that [=canon=]<sub>32</sub> ≤ |n| < 2<sup>[=signif=](32)</sup>.
+        1. Let |n| be an implementation-defined integer such that [=canon=]<sub>32</sub> &leq; |n| &lt; 2<sup>[=signif=](32)</sup>.
         1. Let |f32| be [=nan=](n).
     1. Otherwise,
         1. Let |f32| be |number| rounded to the nearest representable value using IEEE 754-2008 round to nearest, ties to even mode. [[IEEE-754]]
@@ -1296,7 +1312,7 @@ The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript va
 1. If |type| is [=f64=],
     1. Let |number| be [=?=] [$ToNumber$](|v|).
     1. If |number| is **NaN**,
-        1. Let |n| be an implementation-defined integer such that [=canon=]<sub>64</sub> ≤ |n| < 2<sup>[=signif=](64)</sup>.
+        1. Let |n| be an implementation-defined integer such that [=canon=]<sub>64</sub> &leq; |n| &lt; 2<sup>[=signif=](64)</sup>.
         1. Let |f64| be [=nan=](n).
     1. Otherwise,
         1. Let |f64| be |number|.
@@ -1337,6 +1353,31 @@ The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript va
 
 </div>
 
+<div algorithm>
+The algorithm <dfn>IndexValueToU64</dfn>(|v|, |indextype|) asserts that a JavaScript value is the appropriate variant of {{IndexValue}} for an {{IndexType}}, and ensures that its value is in [=u64=] range for WebAssembly embedding operations, by performing the following steps:
+
+1. If |indextype| is "i32",
+    1. If |v| [=is a Number=],
+        1. Assert: Due to WebIDL types and [=[EnforceRange]=], 0 ≤ [=ℝ=](|v|) < 2<sup>64</sup>.
+        1. Return [=ℝ=](|v|) as a WebAssembly [=u64=].
+    1. Otherwise, [=throw=] a {{TypeError}}.
+1. Else if |indextype| is "i64",
+    1. If |v| [=is a BigInt=],
+        1. If |v| is not equal to [=!=] [$ToBigUint64$](|v|), [=throw=] a {{RangeError}}.
+        1. Return [=ℝ=](|v|) as a WebAssembly [=u64=].
+    1. Otherwise, [=throw=] a {{TypeError}}.
+1. Assert: This step is not reached.
+
+</div>
+
+<div algorithm>
+The algorithm <dfn>U64ToIndexValue</dfn>(|v|, |indextype|) converts a [=u64=] value from a WebAssembly embedding operation to the correct variant of {{IndexValue}} for an {{IndexType}}, by performing the following steps:
+
+1. If |indextype| is "i32", return [=𝔽=](|v| interpreted as a [=mathematical value=]).
+1. Else if |indextype| is "i64", return [=ℤ=](|v| interpreted as a [=mathematical value=]).
+1. Assert: This step is not reached.
+
+</div>
 
 <h3 id="tags">Tags</h3>
 
@@ -1369,7 +1410,6 @@ To <dfn>initialize a Tag object</dfn> |tag| from a [=tag address=] |tagAddress|,
 </div>
 
 <div algorithm>
-
 To <dfn>create a Tag object</dfn> from a [=tag address=] |tagAddress|, perform the following steps:
 
 1. Let |map| be the [=surrounding agent=]'s associated [=Tag object cache=].

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -665,15 +665,15 @@ Note: The use of this synchronous API is discouraged, as some implementations so
 
 <pre class="idl">
 dictionary MemoryDescriptor {
-  required [EnforceRange] unsigned long initial;
-  [EnforceRange] unsigned long maximum;
+  required [EnforceRange] unsigned long long initial;
+  [EnforceRange] unsigned long long maximum;
   IndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]
 interface Memory {
   constructor(MemoryDescriptor descriptor);
-  unsigned long grow([EnforceRange] unsigned long delta);
+  unsigned long grow([EnforceRange] unsigned long long delta);
   ArrayBuffer toFixedLengthBuffer();
   ArrayBuffer toResizableBuffer();
   readonly attribute ArrayBuffer buffer;
@@ -857,17 +857,17 @@ enum TableKind {
 
 dictionary TableDescriptor {
   required TableKind element;
-  required [EnforceRange] unsigned long initial;
-  [EnforceRange] unsigned long maximum;
+  required [EnforceRange] unsigned long long initial;
+  [EnforceRange] unsigned long long maximum;
   IndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]
 interface Table {
   constructor(TableDescriptor descriptor, optional any value);
-  unsigned long grow([EnforceRange] unsigned long delta, optional any value);
-  any get([EnforceRange] unsigned long index);
-  undefined set([EnforceRange] unsigned long index, optional any value);
+  unsigned long long grow([EnforceRange] unsigned long long delta, optional any value);
+  any get([EnforceRange] unsigned long long index);
+  undefined set([EnforceRange] unsigned long long index, optional any value);
   readonly attribute unsigned long length;
 };
 </pre>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -556,6 +556,11 @@ enum ImportExportKind {
   "tag"
 };
 
+enum IndexType {
+  "i32",
+  "i64",
+};
+
 dictionary ModuleExportDescriptor {
   required USVString name;
   required ImportExportKind kind;
@@ -659,15 +664,10 @@ Note: The use of this synchronous API is discouraged, as some implementations so
 <h3 id="memories">Memories</h3>
 
 <pre class="idl">
-enum MemoryIndexType {
-  "i32",
-  "i64",
-};
-
 dictionary MemoryDescriptor {
   required [EnforceRange] unsigned long initial;
   [EnforceRange] unsigned long maximum;
-  MemoryIndexType index;
+  IndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]
@@ -859,6 +859,7 @@ dictionary TableDescriptor {
   required TableKind element;
   required [EnforceRange] unsigned long initial;
   [EnforceRange] unsigned long maximum;
+  IndexType index;
 };
 
 [LegacyNamespace=WebAssembly, Exposed=*]
@@ -906,7 +907,8 @@ Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address
         1. Assert: |ref| is not [=error=].
     1. Otherwise,
         1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementType|).
-    1. Let |type| be the [=table type=] {[=table type|min=] |initial|, [=table type|max=] |maximum|} |elementType|.
+    1. If |descriptior|["index"] [=map/exists=], let |index| be |descriptor|["index"]; otherwise, let |index| be "i32".
+    1. Let |type| be the [=table type=] [=table type|index=] |index| {[=table type|min=] |initial|, [=table type|max=] |maximum|} [=table type|refType=] |elementType|.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |tableaddr|) be [=table_alloc=](|store|, |type|, |ref|). <!-- TODO(littledan): Report allocation failure https://github.com/WebAssembly/spec/issues/584 -->
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.

--- a/proposals/memory64/Overview.md
+++ b/proposals/memory64/Overview.md
@@ -23,8 +23,8 @@ made during phase 3 of the proposal and we refer to this addition as "table64".
 ### Implementation Status (table64)
 
 - spec interpreter: [Done](https://github.com/WebAssembly/table64/53)
-- v8/chrome: [WIP](https://g-issues.chromium.org/issues/338024338)
-- Firefox: [WIP](https://g-issues.chromium.org/issues/338024338)
+- v8/chrome: [WIP](https://issues.chromium.org/issues/338024338)
+- Firefox: [WIP](https://bugzilla.mozilla.org/show_bug.cgi?id=1893643)
 - Safari: -
 - wabt: Done
 - binaryen: Done

--- a/proposals/memory64/Overview.md
+++ b/proposals/memory64/Overview.md
@@ -175,7 +175,7 @@ have to support 32-bit memory addresses in their ABI.
     - ```
         C.tables[x] = it limits t
       ------------------------------
-      C ⊦ table.set x : [it] → [t]
+      C ⊦ table.set x : [it t] → []
       ```
   - table.size x
     - ```
@@ -187,7 +187,7 @@ have to support 32-bit memory addresses in their ABI.
     - ```
         C.tables[x] = it limits t
       -------------------------------
-      C ⊦ table.grow x : [it] → [it]
+      C ⊦ table.grow x : [t it] → [it]
       ```
   - table.fill x
     - ```

--- a/test/js-api/table/constructor.any.js
+++ b/test/js-api/table/constructor.any.js
@@ -157,6 +157,16 @@ test(() => {
         },
       };
     },
+
+    get index() {
+      order.push("index");
+      return {
+        valueOf() {
+          order.push("index valueOf");
+          return "i32";
+        },
+      };
+    },
   });
 
   assert_array_equals(order, [
@@ -166,6 +176,8 @@ test(() => {
     "initial valueOf",
     "maximum",
     "maximum valueOf",
+    "index",
+    "index valueOf",
   ]);
 }, "Order of evaluation for descriptor");
 
@@ -206,3 +218,24 @@ test(() => {
   assert_throws_js(TypeError, () => new WebAssembly.Table(argument, "cannot be used as a wasm function"));
   assert_throws_js(TypeError, () => new WebAssembly.Table(argument, 37));
 }, "initialize anyfunc table with a bad default value");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3, "index": "i32" };
+  const table = new WebAssembly.Table(argument);
+  // Once this is merged with the type reflection proposal we should check the
+  // index type of `table`.
+  assert_equals(table.length, 3);
+}, "Table with i32 index constructor");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3, "index": "i64" };
+  const table = new WebAssembly.Table(argument);
+  // Once this is merged with the type reflection proposal we should check the
+  // index type of `table`.
+  assert_equals(table.length, 3);
+}, "Table with i64 index constructor");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3, "index": "unknown" };
+  assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
+}, "Unknown table index");


### PR DESCRIPTION
This PR makes a variety of spec updates related to Memory64, primarily resolving #68, but also addressing many other small issues across the specs.

I recommend reviewing the commits individually; they each have associated commit text explaining the changes.

@sbc100 This PR is currently marked as draft because the `wasm-3.0` branch does not contain all the latest commits from `main`. My work requires some of these new commits, so they show up as part of this PR when they really shouldn't. Can we either merge `wasm-3.0` into main or `main` into `wasm-3.0` to resolve this?