### PR TITLE
Fix small issues in the JS API

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -568,7 +568,7 @@ enum IndexType {
   "i64",
 };
 
-typedef ([EnforceRange] unsigned long long or bigint) IndexValue;
+typedef ([EnforceRange] unsigned long or bigint) IndexValue;
 
 dictionary ModuleExportDescriptor {
   required USVString name;
@@ -682,7 +682,7 @@ dictionary MemoryDescriptor {
 [LegacyNamespace=WebAssembly, Exposed=*]
 interface Memory {
   constructor(MemoryDescriptor descriptor);
-  unsigned long grow(IndexValue delta);
+  IndexValue grow(IndexValue delta);
   ArrayBuffer toFixedLengthBuffer();
   ArrayBuffer toResizableBuffer();
   readonly attribute ArrayBuffer buffer;
@@ -791,7 +791,8 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let |indextype| be the [=index type=] in [=mem_type=](|store|, |memaddr|).
     1. Let |delta64| be [=?=] [=IndexValueToU64=](|delta|, |indextype|).
-    1. Return the result of [=grow the memory buffer|growing the memory buffer=] associated with |memaddr| by |delta64|.
+    1. Let |ret| be the result of [=grow the memory buffer|growing the memory buffer=] associated with |memaddr| by |delta64|.
+    1. Return [=U64ToIndexValue=](|ret|, |indextype|).
 </div>
 
 Immediately after a WebAssembly [=memory.grow=] instruction executes, perform the following steps:
@@ -1363,7 +1364,9 @@ The algorithm <dfn>IndexValueToU64</dfn>(|v|, |indextype|) asserts that a JavaSc
     1. Otherwise, [=throw=] a {{TypeError}}.
 1. Else if |indextype| is "i64",
     1. If |v| [=is a BigInt=],
-        1. If |v| is not equal to [=!=] [$ToBigUint64$](|v|), [=throw=] a {{RangeError}}.
+        1. If |v| is not equal to [=!=] [$ToBigUint64$](|v|), [=throw=] a {{TypeError}}.
+
+            Note: This operation is designed to mirror [=[EnforceRange]=], which [=throws=] a {{TypeError}} for out-of-range numeric values.
         1. Return [=ℝ=](|v|) as a WebAssembly [=u64=].
     1. Otherwise, [=throw=] a {{TypeError}}.
 1. Assert: This step is not reached.


### PR DESCRIPTION
This PR fixes a few lingering issues in the JS API left over from #75:

- `IndexValue` incorrectly used `unsigned long long` instead of `unsigned long`. The current JS API uses `[EnforceRange] unsigned long`, and the `[EnforceRange]` behavior must be preserved.
- The return type of `Memory.grow` should have also been updated to `IndexValue`.
- For symmetry with `[EnforceRange]`, `IndexValueToU64` should have thrown `TypeError` for out-of-range BigInt values instead of `RangeError`.