### PR TITLE
[test][js-api] Fix import of table64 and memory64

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -36,7 +36,10 @@ let spectest = {
   global_f32: 666.6,
   global_f64: 666.6,
   table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
+  table64: new WebAssembly.Table(
+    {initial: 10, maximum: 20, element: 'anyfunc', index: 'i64'}),
   memory: new WebAssembly.Memory({initial: 1, maximum: 2})
+  memory64: new WebAssembly.Memory({initial: 1, maximum: 2, index: 'i64'})
 };
 
 let handler = {

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -37,9 +37,9 @@ let spectest = {
   global_f64: 666.6,
   table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
   table64: new WebAssembly.Table(
-    {initial: 10, maximum: 20, element: 'anyfunc', index: 'i64'}),
-  memory: new WebAssembly.Memory({initial: 1, maximum: 2})
-  memory64: new WebAssembly.Memory({initial: 1, maximum: 2, index: 'i64'})
+    {initial: 10n, maximum: 20n, element: 'anyfunc', index: 'i64'}),
+  memory: new WebAssembly.Memory({initial: 1, maximum: 2}),
+  memory64: new WebAssembly.Memory({initial: 1n, maximum: 2n, index: 'i64'})
 };
 
 let handler = {


### PR DESCRIPTION
Provide imports for 'table64' and 'memory64'. This fixes a js-api test failure.