### PR TITLE
Fix js-api tests

### DIFF
--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -153,7 +153,7 @@ test(() => {
 }, "Memory with i32 index constructor");
 
 test(() => {
-  const argument = { "initial": 1, "index": "i64" };
+  const argument = { "initial": 1n, "index": "i64" };
   const memory = new WebAssembly.Memory(argument);
   assert_Memory(memory, { "size": 1, "index": "i64" });
 }, "Memory with i64 index constructor");

--- a/test/js-api/table/constructor.any.js
+++ b/test/js-api/table/constructor.any.js
@@ -161,8 +161,8 @@ test(() => {
     get index() {
       order.push("index");
       return {
-        valueOf() {
-          order.push("index valueOf");
+        toString() {
+          order.push("index toString");
           return "i32";
         },
       };
@@ -172,12 +172,12 @@ test(() => {
   assert_array_equals(order, [
     "element",
     "element toString",
+    "index",
+    "index toString",
     "initial",
     "initial valueOf",
     "maximum",
     "maximum valueOf",
-    "index",
-    "index valueOf",
   ]);
 }, "Order of evaluation for descriptor");
 
@@ -220,7 +220,7 @@ test(() => {
 }, "initialize anyfunc table with a bad default value");
 
 test(() => {
-  const argument = { "element": "i32", "initial": 3, "index": "i32" };
+  const argument = { "element": "anyfunc", "initial": 3, "index": "i32" };
   const table = new WebAssembly.Table(argument);
   // Once this is merged with the type reflection proposal we should check the
   // index type of `table`.
@@ -228,7 +228,7 @@ test(() => {
 }, "Table with i32 index constructor");
 
 test(() => {
-  const argument = { "element": "i32", "initial": 3, "index": "i64" };
+  const argument = { "element": "anyfunc", "initial": 3n, "index": "i64" };
   const table = new WebAssembly.Table(argument);
   // Once this is merged with the type reflection proposal we should check the
   // index type of `table`.
@@ -236,6 +236,6 @@ test(() => {
 }, "Table with i64 index constructor");
 
 test(() => {
-  const argument = { "element": "i32", "initial": 3, "index": "unknown" };
+  const argument = { "element": "anyfunc", "initial": 3, "index": "unknown" };
   assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
 }, "Unknown table index");


### PR DESCRIPTION
This fixes four things in the JS-API tests:
1. Pass BigInt for i64 WebAssembly.Table and WebAssembly.Memory constructors.
2. Use reference types for tables (would throw a TypeError otherwise).
3. Overwrite 'toString' instead of 'valueOf' for the 'index' property which is a string.
4. 'index' is read after 'element' and before 'initial' in Table construction.