### PR TITLE
Spec test updates

### DIFF
--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -13,9 +13,12 @@
   (global (export "global-mut-i64") (mut i64) (i64.const 66))
   (table (export "table-10-inf") 10 funcref)
   (table (export "table-10-20") 10 20 funcref)
+  (table (export "table64-10-inf") i64 10 funcref)
+  (table (export "table64-10-20") i64 10 20 funcref)
   (memory (export "memory-2-inf") 2)
-  ;; Multiple memories are not yet supported
-  ;; (memory (export "memory-2-4") 2 4)
+  (memory (export "memory-2-4") 2 4)
+  (memory (export "memory64-2-inf") i64 2)
+  (memory (export "memory64-2-4") i64 2 4)
   (tag (export "tag"))
   (tag $tag-i32 (param i32))
   (export "tag-i32" (tag $tag-i32))
@@ -376,6 +379,7 @@
 (module
   (type (func (result i32)))
   (import "spectest" "table" (table $tab 10 20 funcref))
+  (import "test" "table64-10-inf" (table $tab64 i64 10 funcref))
   (elem (table $tab) (i32.const 1) func $f $g)
 
   (func (export "call") (param i32) (result i32)
@@ -395,6 +399,7 @@
 (module
   (type (func (result i32)))
   (table $tab (import "spectest" "table") 10 20 funcref)
+  (table $tab64 (import "test" "table64-10-inf") i64 10 funcref)
   (elem (table $tab) (i32.const 1) func $f $g)
 
   (func (export "call") (param i32) (result i32)
@@ -413,8 +418,12 @@
 (module
   (import "spectest" "table" (table 0 funcref))
   (import "spectest" "table" (table 0 funcref))
+  (import "test" "table64-10-inf" (table i64 10 funcref))
+  (import "test" "table64-10-inf" (table i64 10 funcref))
   (table 10 funcref)
   (table 10 funcref)
+  (table i64 10 funcref)
+  (table i64 10 funcref)
 )
 
 (module (import "test" "table-10-inf" (table 10 funcref)))
@@ -429,6 +438,18 @@
 (module (import "test" "table-10-20" (table 10 25 funcref)))
 (module (import "test" "table-10-20" (table 5 25 funcref)))
 (module (import "test" "table-10-20" (table 0 25 funcref)))
+(module (import "test" "table64-10-inf" (table i64 10 funcref)))
+(module (import "test" "table64-10-inf" (table i64 5 funcref)))
+(module (import "test" "table64-10-inf" (table i64 0 funcref)))
+(module (import "test" "table64-10-20" (table i64 10 funcref)))
+(module (import "test" "table64-10-20" (table i64 5 funcref)))
+(module (import "test" "table64-10-20" (table i64 0 funcref)))
+(module (import "test" "table64-10-20" (table i64 10 20 funcref)))
+(module (import "test" "table64-10-20" (table i64 5 20 funcref)))
+(module (import "test" "table64-10-20" (table i64 0 20 funcref)))
+(module (import "test" "table64-10-20" (table i64 10 25 funcref)))
+(module (import "test" "table64-10-20" (table i64 5 25 funcref)))
+(module (import "test" "table64-10-20" (table i64 0 25 funcref)))
 (module (import "spectest" "table" (table 10 funcref)))
 (module (import "spectest" "table" (table 5 funcref)))
 (module (import "spectest" "table" (table 0 funcref)))
@@ -456,11 +477,27 @@
   "incompatible import type"
 )
 (assert_unlinkable
+  (module (import "test" "table64-10-inf" (table i64 12 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "table64-10-inf" (table i64 10 20 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
   (module (import "test" "table-10-20" (table 12 20 funcref)))
   "incompatible import type"
 )
 (assert_unlinkable
   (module (import "test" "table-10-20" (table 10 18 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "table64-10-20" (table i64 12 20 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "table64-10-20" (table i64 10 18 funcref)))
   "incompatible import type"
 )
 (assert_unlinkable
@@ -489,12 +526,30 @@
   "incompatible import type"
 )
 
+(assert_unlinkable
+  (module (import "test" "table-10-inf" (table i64 10 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "table64-10-inf" (table 10 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "table-10-20" (table i64 10 20 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "table64-10-20" (table 10 20 funcref)))
+  "incompatible import type"
+)
 
 
 ;; Memories
 
 (module
   (import "spectest" "memory" (memory 1 2))
+  (import "test" "memory-2-inf" (memory 2))
+  (import "test" "memory64-2-inf" (memory i64 2))
   (data (memory 0) (i32.const 10) "\10")
 
   (func (export "load") (param i32) (result i32) (i32.load (local.get 0)))
@@ -507,6 +562,8 @@
 
 (module
   (memory (import "spectest" "memory") 1 2)
+  (memory (import "test" "memory-2-inf") 2)
+  (memory (import "test" "memory64-2-inf") i64 2)
   (data (memory 0) (i32.const 10) "\10")
 
   (func (export "load") (param i32) (result i32) (i32.load (local.get 0)))
@@ -519,6 +576,26 @@
 (module (import "test" "memory-2-inf" (memory 2)))
 (module (import "test" "memory-2-inf" (memory 1)))
 (module (import "test" "memory-2-inf" (memory 0)))
+(module (import "test" "memory-2-4" (memory 2)))
+(module (import "test" "memory-2-4" (memory 1)))
+(module (import "test" "memory-2-4" (memory 0)))
+(module (import "test" "memory-2-4" (memory 2 4)))
+(module (import "test" "memory-2-4" (memory 1 4)))
+(module (import "test" "memory-2-4" (memory 0 4)))
+(module (import "test" "memory-2-4" (memory 2 5)))
+(module (import "test" "memory-2-4" (memory 2 6)))
+(module (import "test" "memory64-2-inf" (memory i64 2)))
+(module (import "test" "memory64-2-inf" (memory i64 1)))
+(module (import "test" "memory64-2-inf" (memory i64 0)))
+(module (import "test" "memory64-2-4" (memory i64 2)))
+(module (import "test" "memory64-2-4" (memory i64 1)))
+(module (import "test" "memory64-2-4" (memory i64 0)))
+(module (import "test" "memory64-2-4" (memory i64 2 4)))
+(module (import "test" "memory64-2-4" (memory i64 1 4)))
+(module (import "test" "memory64-2-4" (memory i64 0 4)))
+(module (import "test" "memory64-2-4" (memory i64 2 5)))
+(module (import "test" "memory64-2-4" (memory i64 1 5)))
+(module (import "test" "memory64-2-4" (memory i64 0 5)))
 (module (import "spectest" "memory" (memory 1)))
 (module (import "spectest" "memory" (memory 0)))
 (module (import "spectest" "memory" (memory 1 2)))
@@ -536,11 +613,147 @@
 )
 
 (assert_unlinkable
-  (module (import "test" "memory-2-inf" (memory 3)))
+  (module (import "test" "memory-2-inf" (memory 0 1)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-inf" (memory 0 2)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-inf" (memory 0 3)))
   "incompatible import type"
 )
 (assert_unlinkable
   (module (import "test" "memory-2-inf" (memory 2 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-inf" (memory 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 0 1)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 0 2)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 0 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 2 2)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 2 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 3 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 3 4)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 3 5)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 4 4)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 4 5)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 4)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory 5)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-inf" (memory i64 0 1)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-inf" (memory i64 0 2)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-inf" (memory i64 0 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-inf" (memory i64 2 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-inf" (memory i64 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 0 1)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 0 2)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 0 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 2 2)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 2 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 3 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 3 4)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 3 5)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 4 4)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 4 5)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 3)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 4)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory i64 5)))
   "incompatible import type"
 )
 (assert_unlinkable
@@ -549,6 +762,23 @@
 )
 (assert_unlinkable
   (module (import "spectest" "memory" (memory 1 1)))
+  "incompatible import type"
+)
+
+(assert_unlinkable
+  (module (import "test" "memory-2-inf" (memory i64 2)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-inf" (memory 2)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory-2-4" (memory i64 2 4)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "memory64-2-4" (memory 2 4)))
   "incompatible import type"
 )
 

--- a/test/js-api/memory/assertions.js
+++ b/test/js-api/memory/assertions.js
@@ -27,7 +27,7 @@ function assert_ArrayBuffer(actual, { size=0, shared=false, detached=false }, me
   assert_equals(Object.isExtensible(actual), !shared, "buffer extensibility");
 }
 
-function assert_Memory(memory, { size=0, shared=false, index="i32" }) {
+function assert_Memory(memory, { size=0, shared=false, address="i32" }) {
   assert_equals(Object.getPrototypeOf(memory), WebAssembly.Memory.prototype,
                 "prototype");
   assert_true(Object.isExtensible(memory), "extensible");
@@ -38,6 +38,6 @@ function assert_Memory(memory, { size=0, shared=false, index="i32" }) {
 
   // this depends on js-types proposal implementation
   if (typeof memory.type == "function") {
-    assert_equals(memory.type().index, index, "memory index");
+    assert_equals(memory.type().address, address, "memory address type");
   }
 }

--- a/test/js-api/memory/assertions.js
+++ b/test/js-api/memory/assertions.js
@@ -27,7 +27,7 @@ function assert_ArrayBuffer(actual, { size=0, shared=false, detached=false }, me
   assert_equals(Object.isExtensible(actual), !shared, "buffer extensibility");
 }
 
-function assert_Memory(memory, { size=0, shared=false, index="u32" }) {
+function assert_Memory(memory, { size=0, shared=false, index="i32" }) {
   assert_equals(Object.getPrototypeOf(memory), WebAssembly.Memory.prototype,
                 "prototype");
   assert_true(Object.isExtensible(memory), "extensible");

--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -69,11 +69,11 @@ const outOfRangeValuesI64 = [
 
 for (const value of outOfRangeValuesI64) {
   test(() => {
-    assert_throws_js(TypeError, () => new WebAssembly.Memory({ "index": "i64", "initial": value }));
+    assert_throws_js(TypeError, () => new WebAssembly.Memory({ "address": "i64", "initial": value }));
   }, `Out-of-range initial i64 value in descriptor: ${format_value(value)}`);
 
   test(() => {
-    assert_throws_js(TypeError, () => new WebAssembly.Memory({ "index": "i64", "initial": 0n, "maximum": value }));
+    assert_throws_js(TypeError, () => new WebAssembly.Memory({ "address": "i64", "initial": 0n, "maximum": value }));
   }, `Out-of-range maximum i64 value in descriptor: ${format_value(value)}`);
 }
 
@@ -82,7 +82,7 @@ test(() => {
 }, "Initial value exceeds maximum");
 
 test(() => {
-  assert_throws_js(RangeError, () => new WebAssembly.Memory({ "index": "i64", "initial": 10n, "maximum": 9n }));
+  assert_throws_js(RangeError, () => new WebAssembly.Memory({ "address": "i64", "initial": 10n, "maximum": 9n }));
 }, "Initial value exceeds maximum (i64)");
 
 test(() => {
@@ -98,7 +98,7 @@ test(() => {
         case "initial":
         case "maximum":
           return 0;
-        case "index":
+        case "address":
           return "i32";
         default:
           return undefined;
@@ -132,11 +132,11 @@ test(() => {
       };
     },
 
-    get index() {
-      order.push("index");
+    get address() {
+      order.push("address");
       return {
         toString() {
-          order.push("index toString");
+          order.push("address toString");
           return "i32";
         },
       };
@@ -144,8 +144,8 @@ test(() => {
   });
 
   assert_array_equals(order, [
-    "index",
-    "index toString",
+    "address",
+    "address toString",
     "initial",
     "initial valueOf",
     "maximum",
@@ -166,15 +166,15 @@ test(() => {
 }, "Non-zero initial");
 
 test(() => {
-  const argument = { "index": "i64", "initial": 0n };
+  const argument = { "address": "i64", "initial": 0n };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 0, "index": "i64" });
+  assert_Memory(memory, { "size": 0, "address": "i64" });
 }, "Zero initial (i64)");
 
 test(() => {
-  const argument = { "index": "i64", "initial": 4n };
+  const argument = { "address": "i64", "initial": 4n };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 4, "index": "i64" });
+  assert_Memory(memory, { "size": 4, "address": "i64" });
 }, "Non-zero initial (i64)");
 
 test(() => {
@@ -186,20 +186,20 @@ test(() => {
 test(() => {
   const argument = { "initial": 1 };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "index": "i32" });
-}, "Memory with index parameter omitted");
+  assert_Memory(memory, { "size": 1, "address": "i32" });
+}, "Memory with address parameter omitted");
 
 test(() => {
-  const argument = { "initial": 1, "index": "i32" };
+  const argument = { "initial": 1, "address": "i32" };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "index": "i32" });
-}, "Memory with i32 index constructor");
+  assert_Memory(memory, { "size": 1, "address": "i32" });
+}, "Memory with i32 address constructor");
 
 test(() => {
-  const argument = { "initial": 1n, "index": "i64" };
+  const argument = { "initial": 1n, "address": "i64" };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "index": "i64" });
-}, "Memory with i64 index constructor");
+  assert_Memory(memory, { "size": 1, "address": "i64" });
+}, "Memory with i64 address constructor");
 
 test(() => {
   const argument = { "initial": "3" };
@@ -208,9 +208,9 @@ test(() => {
 }, "Memory with string value for initial");
 
 test(() => {
-  const argument = { "index": "i64", "initial": "3" };
+  const argument = { "address": "i64", "initial": "3" };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 3 });
+  assert_Memory(memory, { "size": 3, "address": "i64" });
 }, "Memory with string value for initial (i64)");
 
 test(() => {
@@ -220,11 +220,11 @@ test(() => {
 }, "Memory with boolean value for initial");
 
 test(() => {
-  const argument = { "index": "i64", "initial": true };
+  const argument = { "address": "i64", "initial": true };
   const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1 });
+  assert_Memory(memory, { "size": 1, "address": "i64" });
 }, "Memory with boolean value for initial (i64)");
 
 test(() => {
-  assert_throws_js(TypeError, () => new WebAssembly.Memory({ "initial": 1, "index": "none" }));
-}, "Unknown memory index");
+  assert_throws_js(TypeError, () => new WebAssembly.Memory({ "initial": 1, "address": "none" }));
+}, "Unknown memory address");

--- a/test/js-api/memory/grow.any.js
+++ b/test/js-api/memory/grow.any.js
@@ -48,7 +48,7 @@ test(() => {
 }, "Zero initial");
 
 test(() => {
-  const argument = { "index": "i64", "initial": 0n };
+  const argument = { "address": "i64", "initial": 0n };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
   assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
@@ -93,7 +93,7 @@ test(() => {
 }, "Non-zero initial");
 
 test(() => {
-  const argument = { "index": "i64", "initial": 3n };
+  const argument = { "address": "i64", "initial": 3n };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
   assert_ArrayBuffer(oldMemory, { "size": 3 }, "Buffer before growing");
@@ -123,7 +123,7 @@ test(() => {
 }, "Zero initial with respected maximum");
 
 test(() => {
-  const argument = { "index": "i64", "initial": 0n, "maximum": 2n };
+  const argument = { "address": "i64", "initial": 0n, "maximum": 2n };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
   assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
@@ -162,7 +162,7 @@ test(() => {
 }, "Zero initial with respected maximum grown twice");
 
 test(() => {
-  const argument = { "index": "i64", "initial": 0n, "maximum": 2n };
+  const argument = { "address": "i64", "initial": 0n, "maximum": 2n };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
   assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
@@ -197,7 +197,7 @@ test(() => {
 }, "Zero initial growing too much");
 
 test(() => {
-  const argument = { "index": "i64", "initial": 1n, "maximum": 2n };
+  const argument = { "address": "i64", "initial": 1n, "maximum": 2n };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
   assert_ArrayBuffer(oldMemory, { "size": 1 }, "Buffer before growing");
@@ -229,13 +229,13 @@ for (const value of outOfRangeValues) {
 
 const outOfRangeValuesI64 = [
   -1n,
-  0x1_0000_0000_0000_0000n,
-  "0x1_0000_0000_0000_0000",
+  0x10000000000000000n,
+  "0x10000000000000000",
 ];
 
 for (const value of outOfRangeValuesI64) {
   test(() => {
-    const argument = { "index": "i64", "initial": 0n };
+    const argument = { "address": "i64", "initial": 0n };
     const memory = new WebAssembly.Memory(argument);
     assert_throws_js(TypeError, () => memory.grow(value));
   }, `Out-of-range i64 argument: ${format_value(value)}`);

--- a/test/js-api/memory/grow.any.js
+++ b/test/js-api/memory/grow.any.js
@@ -48,6 +48,21 @@ test(() => {
 }, "Zero initial");
 
 test(() => {
+  const argument = { "index": "i64", "initial": 0n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
+
+  const result = memory.grow(2n);
+  assert_equals(result, 0n);
+
+  const newMemory = memory.buffer;
+  assert_not_equals(oldMemory, newMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
+  assert_ArrayBuffer(newMemory, { "size": 2 }, "New buffer after growing");
+}, "Zero initial (i64)");
+
+test(() => {
   const argument = { "initial": { valueOf() { return 0 } } };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
@@ -78,6 +93,21 @@ test(() => {
 }, "Non-zero initial");
 
 test(() => {
+  const argument = { "index": "i64", "initial": 3n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 3 }, "Buffer before growing");
+
+  const result = memory.grow(2n);
+  assert_equals(result, 3n);
+
+  const newMemory = memory.buffer;
+  assert_not_equals(oldMemory, newMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
+  assert_ArrayBuffer(newMemory, { "size": 5 }, "New buffer after growing");
+}, "Non-zero initial (i64)");
+
+test(() => {
   const argument = { "initial": 0, "maximum": 2 };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
@@ -91,6 +121,21 @@ test(() => {
   assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
   assert_ArrayBuffer(newMemory, { "size": 2 }, "New buffer after growing");
 }, "Zero initial with respected maximum");
+
+test(() => {
+  const argument = { "index": "i64", "initial": 0n, "maximum": 2n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
+
+  const result = memory.grow(2n);
+  assert_equals(result, 0n);
+
+  const newMemory = memory.buffer;
+  assert_not_equals(oldMemory, newMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
+  assert_ArrayBuffer(newMemory, { "size": 2 }, "New buffer after growing");
+}, "Zero initial with respected maximum (i64)");
 
 test(() => {
   const argument = { "initial": 0, "maximum": 2 };
@@ -117,6 +162,30 @@ test(() => {
 }, "Zero initial with respected maximum grown twice");
 
 test(() => {
+  const argument = { "index": "i64", "initial": 0n, "maximum": 2n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
+
+  const result = memory.grow(1n);
+  assert_equals(result, 0n);
+
+  const newMemory = memory.buffer;
+  assert_not_equals(oldMemory, newMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing once");
+  assert_ArrayBuffer(newMemory, { "size": 1 }, "New buffer after growing once");
+
+  const result2 = memory.grow(1n);
+  assert_equals(result2, 1n);
+
+  const newestMemory = memory.buffer;
+  assert_not_equals(newMemory, newestMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "New buffer after growing twice");
+  assert_ArrayBuffer(newMemory, { "detached": true }, "New buffer after growing twice");
+  assert_ArrayBuffer(newestMemory, { "size": 2 }, "Newest buffer after growing twice");
+}, "Zero initial with respected maximum grown twice (i64)");
+
+test(() => {
   const argument = { "initial": 1, "maximum": 2 };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
@@ -126,6 +195,17 @@ test(() => {
   assert_equals(memory.buffer, oldMemory);
   assert_ArrayBuffer(memory.buffer, { "size": 1 }, "Buffer before trying to grow");
 }, "Zero initial growing too much");
+
+test(() => {
+  const argument = { "index": "i64", "initial": 1n, "maximum": 2n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 1 }, "Buffer before growing");
+
+  assert_throws_js(RangeError, () => memory.grow(2n));
+  assert_equals(memory.buffer, oldMemory);
+  assert_ArrayBuffer(memory.buffer, { "size": 1 }, "Buffer before trying to grow");
+}, "Zero initial growing too much (i64)");
 
 const outOfRangeValues = [
   undefined,
@@ -145,6 +225,20 @@ for (const value of outOfRangeValues) {
     const memory = new WebAssembly.Memory(argument);
     assert_throws_js(TypeError, () => memory.grow(value));
   }, `Out-of-range argument: ${format_value(value)}`);
+}
+
+const outOfRangeValuesI64 = [
+  -1n,
+  0x1_0000_0000_0000_0000n,
+  "0x1_0000_0000_0000_0000",
+];
+
+for (const value of outOfRangeValuesI64) {
+  test(() => {
+    const argument = { "index": "i64", "initial": 0n };
+    const memory = new WebAssembly.Memory(argument);
+    assert_throws_js(TypeError, () => memory.grow(value));
+  }, `Out-of-range i64 argument: ${format_value(value)}`);
 }
 
 test(() => {

--- a/test/js-api/table/assertions.js
+++ b/test/js-api/table/assertions.js
@@ -1,18 +1,18 @@
-function assert_equal_to_array(table, expected, message, index = "i32") {
-  function idx(i) {
-    return index === "i64" ? BigInt(i) : i;
+function assert_equal_to_array(table, expected, message, address = "i32") {
+  function addr(i) {
+    return address === "i64" ? BigInt(i) : i;
   }
 
-  assert_equals(table.length, idx(expected.length), `${message}: length`);
+  assert_equals(table.length, addr(expected.length), `${message}: length`);
   // The argument check in get() happens before the range check, and negative numbers
   // are illegal, hence will throw TypeError per spec.
-  assert_throws_js(TypeError, () => table.get(idx(-1)), `${message}: table.get(-1)`);
+  assert_throws_js(TypeError, () => table.get(addr(-1)), `${message}: table.get(-1)`);
   for (let i = 0; i < expected.length; ++i) {
-    assert_equals(table.get(idx(i)), expected[i], `${message}: table.get(${i} of ${expected.length})`);
+    assert_equals(table.get(addr(i)), expected[i], `${message}: table.get(${i} of ${expected.length})`);
   }
-  assert_throws_js(RangeError, () => table.get(idx(expected.length)),
+  assert_throws_js(RangeError, () => table.get(addr(expected.length)),
                    `${message}: table.get(${expected.length} of ${expected.length})`);
-  assert_throws_js(RangeError, () => table.get(idx(expected.length + 1)),
+  assert_throws_js(RangeError, () => table.get(addr(expected.length + 1)),
                    `${message}: table.get(${expected.length + 1} of ${expected.length})`);
 }
 

--- a/test/js-api/table/assertions.js
+++ b/test/js-api/table/assertions.js
@@ -1,24 +1,29 @@
-function assert_equal_to_array(table, expected, message) {
-  assert_equals(table.length, expected.length, `${message}: length`);
+function assert_equal_to_array(table, expected, message, index = "i32") {
+  function idx(i) {
+    return index === "i64" ? BigInt(i) : i;
+  }
+
+  assert_equals(table.length, idx(expected.length), `${message}: length`);
   // The argument check in get() happens before the range check, and negative numbers
   // are illegal, hence will throw TypeError per spec.
-  assert_throws_js(TypeError, () => table.get(-1), `${message}: table.get(-1)`);
+  assert_throws_js(TypeError, () => table.get(idx(-1)), `${message}: table.get(-1)`);
   for (let i = 0; i < expected.length; ++i) {
-    assert_equals(table.get(i), expected[i], `${message}: table.get(${i} of ${expected.length})`);
+    assert_equals(table.get(idx(i)), expected[i], `${message}: table.get(${i} of ${expected.length})`);
   }
-  assert_throws_js(RangeError, () => table.get(expected.length),
+  assert_throws_js(RangeError, () => table.get(idx(expected.length)),
                    `${message}: table.get(${expected.length} of ${expected.length})`);
-  assert_throws_js(RangeError, () => table.get(expected.length + 1),
+  assert_throws_js(RangeError, () => table.get(idx(expected.length + 1)),
                    `${message}: table.get(${expected.length + 1} of ${expected.length})`);
 }
 
-function assert_Table(actual, expected) {
+function assert_Table(actual, expected, index = "i32") {
   assert_equals(Object.getPrototypeOf(actual), WebAssembly.Table.prototype,
                 "prototype");
   assert_true(Object.isExtensible(actual), "extensible");
 
   assert_equals(actual.length, expected.length, "length");
   for (let i = 0; i < expected.length; ++i) {
-    assert_equals(actual.get(i), null, `actual.get(${i})`);
+    const idx = index === "i64" ? BigInt(i) : i;
+    assert_equals(actual.get(idx), null, `actual.get(${idx})`);
   }
 }

--- a/test/js-api/table/assertions.js
+++ b/test/js-api/table/assertions.js
@@ -22,8 +22,7 @@ function assert_Table(actual, expected, index = "i32") {
   assert_true(Object.isExtensible(actual), "extensible");
 
   assert_equals(actual.length, expected.length, "length");
-  for (let i = 0; i < expected.length; ++i) {
-    const idx = index === "i64" ? BigInt(i) : i;
-    assert_equals(actual.get(idx), null, `actual.get(${idx})`);
+  for (let i = index === "i64" ? 0n : 0; i < expected.length; ++i) {
+    assert_equals(actual.get(i), null, `actual.get(${i})`);
   }
 }

--- a/test/js-api/table/assertions.js
+++ b/test/js-api/table/assertions.js
@@ -16,13 +16,13 @@ function assert_equal_to_array(table, expected, message, index = "i32") {
                    `${message}: table.get(${expected.length + 1} of ${expected.length})`);
 }
 
-function assert_Table(actual, expected, index = "i32") {
+function assert_Table(actual, expected, address = "i32") {
   assert_equals(Object.getPrototypeOf(actual), WebAssembly.Table.prototype,
                 "prototype");
   assert_true(Object.isExtensible(actual), "extensible");
 
   assert_equals(actual.length, expected.length, "length");
-  for (let i = index === "i64" ? 0n : 0; i < expected.length; ++i) {
+  for (let i = address === "i64" ? 0n : 0; i < expected.length; ++i) {
     assert_equals(actual.get(i), null, `actual.get(${i})`);
   }
 }

--- a/test/js-api/table/constructor.any.js
+++ b/test/js-api/table/constructor.any.js
@@ -71,9 +71,28 @@ for (const value of outOfRangeValues) {
   }, `Out-of-range maximum value in descriptor: ${format_value(value)}`);
 }
 
+const outOfRangeValuesI64 = [
+  -1n,
+  0x1_0000_0000_0000_0000n,
+];
+
+for (const value of outOfRangeValuesI64) {
+  test(() => {
+    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "index": "i64", "initial": value }));
+  }, `Out-of-range initial i64 value in descriptor: ${format_value(value)}`);
+
+  test(() => {
+    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "index": "i64", "initial": 0n, "maximum": value }));
+  }, `Out-of-range maximum i64 value in descriptor: ${format_value(value)}`);
+}
+
 test(() => {
   assert_throws_js(RangeError, () => new WebAssembly.Table({ "element": "anyfunc", "initial": 10, "maximum": 9 }));
 }, "Initial value exceeds maximum");
+
+test(() => {
+  assert_throws_js(RangeError, () => new WebAssembly.Table({ "element": "anyfunc", "index": "i64", "initial": 10n, "maximum": 9n }));
+}, "Initial value exceeds maximum (i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0 };
@@ -86,6 +105,18 @@ test(() => {
   const table = new WebAssembly.Table(argument);
   assert_Table(table, { "length": 5 });
 }, "Basic (non-zero)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "index": "i64", "initial": 0n };
+  const table = new WebAssembly.Table(argument);
+  assert_Table(table, { "length": 0n }, "i64");
+}, "Basic (zero, i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_Table(table, { "length": 5n }, "i64");
+}, "Basic (non-zero, i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0 };
@@ -232,10 +263,82 @@ test(() => {
   const table = new WebAssembly.Table(argument);
   // Once this is merged with the type reflection proposal we should check the
   // index type of `table`.
-  assert_equals(table.length, 3);
+  assert_equals(table.length, 3n);
 }, "Table with i64 index constructor");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": "3", "index": "i32" };
+  const table = new WebAssembly.Table(argument);
+  assert_equals(table.length, 3);
+}, "Table with string value for initial");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": "3", "index": "i64" };
+  const table = new WebAssembly.Table(argument);
+  assert_equals(table.length, 3n);
+}, "Table with string value for initial (i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": true, "index": "i32" };
+  const table = new WebAssembly.Table(argument);
+  assert_equals(table.length, 1);
+}, "Table with boolean value for initial");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": true, "index": "i64" };
+  const table = new WebAssembly.Table(argument);
+  assert_equals(table.length, 1n);
+}, "Table with boolean value for initial (i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": 0, "maximum": "3", "index": "i32" };
+  const table = new WebAssembly.Table(argument);
+  table.grow(3);
+  assert_equals(table.length, 3);
+}, "Table with string value for maximum");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": 0n, "maximum": "3", "index": "i64" };
+  const table = new WebAssembly.Table(argument);
+  table.grow(3n);
+  assert_equals(table.length, 3n);
+}, "Table with string value for maximum (i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": 0, "maximum": true, "index": "i32" };
+  const table = new WebAssembly.Table(argument);
+  table.grow(1);
+  assert_equals(table.length, 1);
+}, "Table with boolean value for maximum");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": 0n, "maximum": true, "index": "i64" };
+  const table = new WebAssembly.Table(argument);
+  table.grow(1n);
+  assert_equals(table.length, 1n);
+}, "Table with boolean value for maximum (i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 3, "index": "unknown" };
   assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
 }, "Unknown table index");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3n };
+  assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
+}, "initialize table with a wrong initial type");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3, "maximum": 10n };
+  assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
+}, "initialize table with a wrong maximum type");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3 };
+  assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
+}, "initialize table with a wrong initial type (i64)");
+
+test(() => {
+  const argument = { "element": "i32", "initial": 3n, "maximum": 10 };
+  assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
+}, "initialize table with a wrong maximum type (i64)");

--- a/test/js-api/table/constructor.any.js
+++ b/test/js-api/table/constructor.any.js
@@ -78,11 +78,11 @@ const outOfRangeValuesI64 = [
 
 for (const value of outOfRangeValuesI64) {
   test(() => {
-    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "index": "i64", "initial": value }));
+    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": value }));
   }, `Out-of-range initial i64 value in descriptor: ${format_value(value)}`);
 
   test(() => {
-    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "index": "i64", "initial": 0n, "maximum": value }));
+    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": 0n, "maximum": value }));
   }, `Out-of-range maximum i64 value in descriptor: ${format_value(value)}`);
 }
 
@@ -91,7 +91,7 @@ test(() => {
 }, "Initial value exceeds maximum");
 
 test(() => {
-  assert_throws_js(RangeError, () => new WebAssembly.Table({ "element": "anyfunc", "index": "i64", "initial": 10n, "maximum": 9n }));
+  assert_throws_js(RangeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": 10n, "maximum": 9n }));
 }, "Initial value exceeds maximum (i64)");
 
 test(() => {
@@ -107,13 +107,13 @@ test(() => {
 }, "Basic (non-zero)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "index": "i64", "initial": 0n };
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 0n };
   const table = new WebAssembly.Table(argument);
   assert_Table(table, { "length": 0n }, "i64");
 }, "Basic (zero, i64)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
   const table = new WebAssembly.Table(argument);
   assert_Table(table, { "length": 5n }, "i64");
 }, "Basic (non-zero, i64)");
@@ -189,11 +189,11 @@ test(() => {
       };
     },
 
-    get index() {
-      order.push("index");
+    get address() {
+      order.push("address");
       return {
         toString() {
-          order.push("index toString");
+          order.push("address toString");
           return "i32";
         },
       };
@@ -203,8 +203,8 @@ test(() => {
   assert_array_equals(order, [
     "element",
     "element toString",
-    "index",
-    "index toString",
+    "address",
+    "address toString",
     "initial",
     "initial valueOf",
     "maximum",
@@ -251,77 +251,77 @@ test(() => {
 }, "initialize anyfunc table with a bad default value");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 3, "index": "i32" };
+  const argument = { "element": "anyfunc", "initial": 3, "address": "i32" };
   const table = new WebAssembly.Table(argument);
   // Once this is merged with the type reflection proposal we should check the
   // address type of `table`.
   assert_equals(table.length, 3);
-}, "Table with i32 index constructor");
+}, "Table with i32 address constructor");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 3n, "index": "i64" };
+  const argument = { "element": "anyfunc", "initial": 3n, "address": "i64" };
   const table = new WebAssembly.Table(argument);
   // Once this is merged with the type reflection proposal we should check the
   // address type of `table`.
   assert_equals(table.length, 3n);
-}, "Table with i64 index constructor");
+}, "Table with i64 address constructor");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": "3", "index": "i32" };
+  const argument = { "element": "anyfunc", "initial": "3", "address": "i32" };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 3);
 }, "Table with string value for initial");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": "3", "index": "i64" };
+  const argument = { "element": "anyfunc", "initial": "3", "address": "i64" };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 3n);
 }, "Table with string value for initial (i64)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": true, "index": "i32" };
+  const argument = { "element": "anyfunc", "initial": true, "address": "i32" };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 1);
 }, "Table with boolean value for initial");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": true, "index": "i64" };
+  const argument = { "element": "anyfunc", "initial": true, "address": "i64" };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 1n);
 }, "Table with boolean value for initial (i64)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0, "maximum": "3", "index": "i32" };
+  const argument = { "element": "anyfunc", "initial": 0, "maximum": "3", "address": "i32" };
   const table = new WebAssembly.Table(argument);
   table.grow(3);
   assert_equals(table.length, 3);
 }, "Table with string value for maximum");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0n, "maximum": "3", "index": "i64" };
+  const argument = { "element": "anyfunc", "initial": 0n, "maximum": "3", "address": "i64" };
   const table = new WebAssembly.Table(argument);
   table.grow(3n);
   assert_equals(table.length, 3n);
 }, "Table with string value for maximum (i64)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0, "maximum": true, "index": "i32" };
+  const argument = { "element": "anyfunc", "initial": 0, "maximum": true, "address": "i32" };
   const table = new WebAssembly.Table(argument);
   table.grow(1);
   assert_equals(table.length, 1);
 }, "Table with boolean value for maximum");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0n, "maximum": true, "index": "i64" };
+  const argument = { "element": "anyfunc", "initial": 0n, "maximum": true, "address": "i64" };
   const table = new WebAssembly.Table(argument);
   table.grow(1n);
   assert_equals(table.length, 1n);
 }, "Table with boolean value for maximum (i64)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 3, "index": "unknown" };
+  const argument = { "element": "anyfunc", "initial": 3, "address": "unknown" };
   assert_throws_js(TypeError, () => new WebAssembly.Table(argument));
-}, "Unknown table index");
+}, "Unknown table address");
 
 test(() => {
   const argument = { "element": "i32", "initial": 3n };

--- a/test/js-api/table/get-set.any.js
+++ b/test/js-api/table/get-set.any.js
@@ -101,6 +101,23 @@ test(() => {
 }, "Basic");
 
 test(() => {
+  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, [null, null, null, null, null], undefined, "i64");
+
+  const {fn, fn2} = functions;
+
+  assert_equals(table.set(0n, fn), undefined, "set() returns undefined.");
+  table.set(2n, fn2);
+  table.set(4n, fn);
+
+  assert_equal_to_array(table, [fn, null, fn2, null, fn], undefined, "i64");
+
+  table.set(0n, null);
+  assert_equal_to_array(table, [null, null, fn2, null, fn], undefined, "i64");
+}, "Basic (i64)");
+
+test(() => {
   const argument = { "element": "anyfunc", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null, null, null, null, null]);
@@ -119,6 +136,24 @@ test(() => {
 }, "Growing");
 
 test(() => {
+  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, [null, null, null, null, null], undefined, "i64");
+
+  const {fn, fn2} = functions;
+
+  table.set(0n, fn);
+  table.set(2n, fn2);
+  table.set(4n, fn);
+
+  assert_equal_to_array(table, [fn, null, fn2, null, fn], undefined, "i64");
+
+  table.grow(4n);
+
+  assert_equal_to_array(table, [fn, null, fn2, null, fn, null, null, null, null], undefined, "i64");
+}, "Growing (i64)");
+
+test(() => {
   const argument = { "element": "anyfunc", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null, null, null, null, null]);
@@ -131,6 +166,20 @@ test(() => {
   assert_throws_js(RangeError, () => table.set(5, fn));
   assert_equal_to_array(table, [null, null, null, null, null]);
 }, "Setting out-of-bounds");
+
+test(() => {
+  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, [null, null, null, null, null], undefined, "i64");
+
+  const {fn} = functions;
+
+  // -1 is the wrong type hence the type check on entry gets this
+  // before the range check does.
+  assert_throws_js(TypeError, () => table.set(-1n, fn));
+  assert_throws_js(RangeError, () => table.set(5n, fn));
+  assert_equal_to_array(table, [null, null, null, null, null], undefined, "i64");
+}, "Setting out-of-bounds (i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 1 };
@@ -198,6 +247,26 @@ for (const value of outOfRangeValues) {
     const table = new WebAssembly.Table(argument);
     assert_throws_js(TypeError, () => table.set(value, null));
   }, `Setting out-of-range argument: ${format_value(value)}`);
+}
+
+const outOfRangeValuesI64 = [
+  -1n,
+  0x1_0000_0000_0000_0000n,
+  "0x1_0000_0000_0000_0000",
+];
+
+for (const value of outOfRangeValuesI64) {
+  test(() => {
+    const argument = { "element": "anyfunc", "index": "i64", "initial": 1n };
+    const table = new WebAssembly.Table(argument);
+    assert_throws_js(TypeError, () => table.get(value));
+  }, `Getting out-of-range argument (i64): ${format_value(value)}`);
+
+  test(() => {
+    const argument = { "element": "anyfunc", "index": "i64", "initial": 1n };
+    const table = new WebAssembly.Table(argument);
+    assert_throws_js(TypeError, () => table.set(value, null));
+  }, `Setting out-of-range argument (i64): ${format_value(value)}`);
 }
 
 test(() => {

--- a/test/js-api/table/get-set.any.js
+++ b/test/js-api/table/get-set.any.js
@@ -101,7 +101,7 @@ test(() => {
 }, "Basic");
 
 test(() => {
-  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null, null, null, null, null], undefined, "i64");
 
@@ -136,7 +136,7 @@ test(() => {
 }, "Growing");
 
 test(() => {
-  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null, null, null, null, null], undefined, "i64");
 
@@ -168,7 +168,7 @@ test(() => {
 }, "Setting out-of-bounds");
 
 test(() => {
-  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, [null, null, null, null, null], undefined, "i64");
 
@@ -251,19 +251,19 @@ for (const value of outOfRangeValues) {
 
 const outOfRangeValuesI64 = [
   -1n,
-  0x1_0000_0000_0000_0000n,
-  "0x1_0000_0000_0000_0000",
+  0x10000000000000000n,
+  "0x10000000000000000",
 ];
 
 for (const value of outOfRangeValuesI64) {
   test(() => {
-    const argument = { "element": "anyfunc", "index": "i64", "initial": 1n };
+    const argument = { "element": "anyfunc", "address": "i64", "initial": 1n };
     const table = new WebAssembly.Table(argument);
     assert_throws_js(TypeError, () => table.get(value));
   }, `Getting out-of-range argument (i64): ${format_value(value)}`);
 
   test(() => {
-    const argument = { "element": "anyfunc", "index": "i64", "initial": 1n };
+    const argument = { "element": "anyfunc", "address": "i64", "initial": 1n };
     const table = new WebAssembly.Table(argument);
     assert_throws_js(TypeError, () => table.set(value, null));
   }, `Setting out-of-range argument (i64): ${format_value(value)}`);

--- a/test/js-api/table/grow.any.js
+++ b/test/js-api/table/grow.any.js
@@ -48,7 +48,7 @@ test(() => {
 }, "Basic i32");
 
 test(() => {
-  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(5), "before", "i64");
 
@@ -68,7 +68,7 @@ test(() => {
 }, "Reached maximum (i32)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "index": "i64", "initial": 3n, "maximum": 5n };
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 3n, "maximum": 5n };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(3), "before", "i64");
 
@@ -87,7 +87,7 @@ test(() => {
 }, "Exceeded maximum (i32)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "index": "i64", "initial": 2n, "maximum": 5n };
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 2n, "maximum": 5n };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(2), "before", "i64");
 
@@ -117,13 +117,13 @@ for (const value of outOfRangeValues) {
 
 const outOfRangeValuesI64 = [
   -1n,
-  0x1_0000_0000_0000_0000n,
-  "0x1_0000_0000_0000_0000",
+  0x10000000000000000n,
+  "0x10000000000000000",
 ];
 
 for (const value of outOfRangeValuesI64) {
   test(() => {
-    const argument = { "element": "anyfunc", "index": "i64", "initial": 1n };
+    const argument = { "element": "anyfunc", "address": "i64", "initial": 1n };
     const table = new WebAssembly.Table(argument);
     assert_throws_js(TypeError, () => table.grow(value));
   }, `Out-of-range i64 argument: ${format_value(value)}`);

--- a/test/js-api/table/grow.any.js
+++ b/test/js-api/table/grow.any.js
@@ -45,7 +45,17 @@ test(() => {
   const result = table.grow(3);
   assert_equals(result, 5);
   assert_equal_to_array(table, nulls(8), "after");
-}, "Basic");
+}, "Basic i32");
+
+test(() => {
+  const argument = { "element": "anyfunc", "index": "i64", "initial": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, nulls(5), "before", "i64");
+
+  const result = table.grow(3n);
+  assert_equals(result, 5n);
+  assert_equal_to_array(table, nulls(8), "after", "i64");
+}, "Basic i64");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 3, "maximum": 5 };
@@ -55,7 +65,17 @@ test(() => {
   const result = table.grow(2);
   assert_equals(result, 3);
   assert_equal_to_array(table, nulls(5), "after");
-}, "Reached maximum");
+}, "Reached maximum (i32)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "index": "i64", "initial": 3n, "maximum": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, nulls(3), "before", "i64");
+
+  const result = table.grow(2n);
+  assert_equals(result, 3n);
+  assert_equal_to_array(table, nulls(5), "after", "i64");
+}, "Reached maximum (i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 2, "maximum": 5 };
@@ -64,7 +84,16 @@ test(() => {
 
   assert_throws_js(RangeError, () => table.grow(4));
   assert_equal_to_array(table, nulls(2), "after");
-}, "Exceeded maximum");
+}, "Exceeded maximum (i32)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "index": "i64", "initial": 2n, "maximum": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, nulls(2), "before", "i64");
+
+  assert_throws_js(RangeError, () => table.grow(4n));
+  assert_equal_to_array(table, nulls(2), "after", "i64");
+}, "Exceeded maximum (i64)");
 
 const outOfRangeValues = [
   undefined,
@@ -84,6 +113,20 @@ for (const value of outOfRangeValues) {
     const table = new WebAssembly.Table(argument);
     assert_throws_js(TypeError, () => table.grow(value));
   }, `Out-of-range argument: ${format_value(value)}`);
+}
+
+const outOfRangeValuesI64 = [
+  -1n,
+  0x1_0000_0000_0000_0000n,
+  "0x1_0000_0000_0000_0000",
+];
+
+for (const value of outOfRangeValuesI64) {
+  test(() => {
+    const argument = { "element": "anyfunc", "index": "i64", "initial": 1n };
+    const table = new WebAssembly.Table(argument);
+    assert_throws_js(TypeError, () => table.grow(value));
+  }, `Out-of-range i64 argument: ${format_value(value)}`);
 }
 
 test(() => {


### PR DESCRIPTION
Adds core and JS API spec tests for recent updates as described in #80.

We needed fewer updates than I had originally thought. See the individual commits. Tests I did _not_ have to write include:

- Offsets outside of i32 range for memory32 (#76) (this was already present in the spec interpreter and spec tests, just not in the actual spec)
- Tests for call_indirect on table64 (@sbc100 already added these)

Beyond adding tests for memory64, I also took the opportunity to significantly enhance the memory import tests, since multi-memory is now standard.

Resolves #80.