### PR TITLE
Update JS-test generation after #90 and #92

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -37,9 +37,9 @@ let spectest = {
   global_f64: 666.6,
   table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
   table64: new WebAssembly.Table(
-    {initial: 10n, maximum: 20n, element: 'anyfunc', index: 'i64'}),
+    {initial: 10n, maximum: 20n, element: 'anyfunc', address: 'i64'}),
   memory: new WebAssembly.Memory({initial: 1, maximum: 2}),
-  memory64: new WebAssembly.Memory({initial: 1n, maximum: 2n, index: 'i64'})
+  memory64: new WebAssembly.Memory({initial: 1n, maximum: 2n, address: 'i64'})
 };
 
 let handler = {


### PR DESCRIPTION
"index" was renamed to "address" in #92 (after #90).
Without this change, all JS tests generated from the core tests will fail.