### PR TITLE
Add spec tests for table maximum >=2^32

### DIFF
--- a/test/core/table.wast
+++ b/test/core/table.wast
@@ -53,6 +53,8 @@
 (module (table i64 1 256 funcref))
 (module (table i64 0 65536 funcref))
 (module (table i64 0 0xffff_ffff funcref))
+(module (table i64 0 0x1_0000_0000 funcref))
+(module (table i64 0 0xffff_ffff_ffff_ffff funcref))
 
 (module (table i64 0 funcref) (table i64 0 funcref))
 (module (table (import "spectest" "table64") i64 0 funcref) (table i64 0 funcref))


### PR DESCRIPTION
The table maximum is now a 64-bit values, so test that we actually support values outside the 32-bit range.